### PR TITLE
Fix deprecations on Julia v0.6, drop v0.4 support, add badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: 0.6
+    - julia: nightly
 notifications:
   email: false
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,12 @@ notifications:
   email: false
 sudo: false
 addons:
-  apt:
-    packages:
-      - gfortran
+  apt_packages:
+    - gfortran
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update; 
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       brew install gcc;
-    fi ; 
+    fi
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # ODEInterface
 
-[![Build Status](https://travis-ci.org/luchr/ODEInterface.jl.svg?branch=master)](https://travis-ci.org/luchr/ODEInterface.jl)
+[![Travis](https://travis-ci.org/luchr/ODEInterface.jl.svg?branch=master)](https://travis-ci.org/luchr/ODEInterface.jl)
+#[![AppVeyor](https://ci.appveyor.com/api/projects/status/mue0n1yhlxq4ok8d/branch/master?svg=true)](https://ci.appveyor.com/project/luchr/ode-jl/branch/master)
+#[![Coverage Status](https://img.shields.io/coveralls/luchr/ODEInterface.jl.svg)](https://coveralls.io/r/luchr/ODEInterface.jl)
+[![ODEInterface](http://pkg.julialang.org/badges/ODEInterface_0.4.svg)](http://pkg.julialang.org/?pkg=ODEInterface)
+[![ODEInterface](http://pkg.julialang.org/badges/ODEInterface_0.5.svg)](http://pkg.julialang.org/?pkg=ODEInterface)
+[![ODEInterface](http://pkg.julialang.org/badges/ODEInterface_0.6.svg)](http://pkg.julialang.org/?pkg=ODEInterface)
 
 This julia module provides an interface to solvers for 
 ordinary differential equations (ODEs) written in Fortran

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4
+julia 0.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,18 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+
+matrix:
+  allow_failures:
+    - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+    - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+    - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+    - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/src/Banded.jl
+++ b/src/Banded.jl
@@ -99,27 +99,23 @@ immutable BandedMatrix{T}    <: AbstractMatrix{T}
   u            :: Integer               # upper bandwidth
   entries      :: Matrix{T}             # array with entries
   
-  function BandedMatrix{T}(m::Integer,n::Integer,l::Integer,u::Integer,
-                                entries::Matrix{T})
-   if !(m≥1); throw(ArgumentErrorODE("requirement m≥1",:m));end
-   if !(n≥1); throw(ArgumentErrorODE("requirement n≥1",:n));end
-   if !(l≥0); throw(ArgumentErrorODE("requirement l≥0",:l));end
-   if !(u≥0); throw(ArgumentErrorODE("requirement u≥0",:u));end
-   if l+1 > m 
-     throw(ArgumentErrorODE("requirement: l=$l ≤ m-1 = $m -1",:l))
-   end
-   if u+1 > n
-     throw(ArgumentErrorODE("requirement: u=$u ≤ n-1 = $n - 1",:u))
-   end
-   es = size(entries)
-   if es ≠ (1+l+u,n)
-     throw(ArgumentErrorODE(
-       "requirement: $es=size(entries) == (1+l+u,n); l=$l, u=$u, n=$n",
-       :entries))
-   end
-   fill!(entries,zero(T))
-   return new(m,n,l,u,entries)
-  end
+    function (::Type{BandedMatrix{T}}){T}(m::Integer, n::Integer, l::Integer, u::Integer,
+                                          entries::Matrix{T})
+        m≥1 || throw(ArgumentErrorODE("requirement m≥1", :m))
+        n≥1 || throw(ArgumentErrorODE("requirement n≥1", :n))
+        l≥0 || throw(ArgumentErrorODE("requirement l≥0", :l))
+        u≥0 || throw(ArgumentErrorODE("requirement u≥0", :u))
+        l+1 > m &&
+            throw(ArgumentErrorODE("requirement: l=$l ≤ m-1 = $m -1", :l))
+        u+1 > n &&
+            throw(ArgumentErrorODE("requirement: u=$u ≤ n-1 = $n - 1", :u))
+        es = size(entries)
+        es ≠ (1+l+u, n) &&
+            throw(ArgumentErrorODE("requirement: $es=size(entries) == (1+l+u,n); l=$l, u=$u, n=$n",
+                                   :entries))
+        fill!(entries, zero(T))
+        new{T}(m, n, l, u, entries)
+    end
 end
 
 """

--- a/src/Base.jl
+++ b/src/Base.jl
@@ -140,11 +140,13 @@ if !isdefined(Base, :unsafe_wrap)
   end
 end
 
+# Work around syntax changes in v0.6 without requiring Compat
+eval(Expr(:abstract, :(ODEinternalCallInfos)))
 """
   Type encapsulating all required data for ODE-Solver-Callbacks.
   
   For further explanation see, `GlobalCallInfoDict`
-  """
-abstract ODEinternalCallInfos
+"""
+ODEinternalCallInfos
 
 # vim:syn=julia:cc=79:fdm=indent:

--- a/src/Bvpsol.jl
+++ b/src/Bvpsol.jl
@@ -108,6 +108,8 @@ type BvpsolArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   IW      :: Vector{FInt}      # integer workspace
 
     ## Allow uninitialized construction
+    # This ugly syntax is only for v0.5 compatibility: after v0.5 is dropped, it should be:
+    # BvpsolArguments{T}() where {T} = new{T}()
     (::Type{BvpsolArguments{T}}){T}() = new{T}()
 end
 

--- a/src/Bvpsol.jl
+++ b/src/Bvpsol.jl
@@ -106,10 +106,9 @@ type BvpsolArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   RW      :: Vector{Float64}   # real workspace
   IIW     :: Vector{FInt}      # length of workspace IW
   IW      :: Vector{FInt}      # integer workspace
+
     ## Allow uninitialized construction
-  function BvpsolArguments()
-    return new()
-  end
+    (::Type{BvpsolArguments{T}}){T}() = new{T}()
 end
 
 """

--- a/src/Dopri.jl
+++ b/src/Dopri.jl
@@ -76,6 +76,8 @@ type DopriArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   IDID    :: Vector{FInt}      # Status code
 
     ## Allow uninitialized construction
+    # This ugly syntax is only for v0.5 compatibility: after v0.5 is dropped, it should be:
+    # DopriArguments{T}() where {T} = new{T}()
     (::Type{DopriArguments{T}}){T}() = new{T}()
 end
 

--- a/src/Dopri.jl
+++ b/src/Dopri.jl
@@ -74,10 +74,9 @@ type DopriArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   RPAR    :: Vector{Float64}   # add. double-array
   IPAR    :: Ref{DopriInternalCallInfos} # misuse IPAR
   IDID    :: Vector{FInt}      # Status code
+
     ## Allow uninitialized construction
-  function DopriArguments()
-    return new()
-  end
+    (::Type{DopriArguments{T}}){T}() = new{T}()
 end
 
 """

--- a/src/Error.jl
+++ b/src/Error.jl
@@ -12,12 +12,13 @@ macro import_exceptions()
   )
 end
 
+eval(Expr(:abstract, :(WrappedODEException <: Base.WrappedException)))
 """
   The ancestor for all wrapped exceptions in ODEInterface.
   
   Required fields: msg, error
-  """
-abstract WrappedODEException <: Base.WrappedException
+"""
+WrappedODEException
 
 function showerror(io::IO,e::WrappedODEException)
   println(io,e.msg)

--- a/src/ODEInterface.jl
+++ b/src/ODEInterface.jl
@@ -161,11 +161,12 @@ end
   """
 const solverInfo = Vector{SolverInfo}() 
 
-
+# Work around syntax changes in v0.6 without requiring Compat
+eval(Expr(:abstract, :(AbstractArgumentsODESolver{FInt} <: Any)))
 """
   Ancestor for all types storing arguments for ODE-(C-/Fortran-)solvers.
-  """
-abstract AbstractArgumentsODESolver{FInt} <: Any
+"""
+AbstractArgumentODESolver
 
 # Common options
 """macro for importing common OPT options."""

--- a/src/Odex.jl
+++ b/src/Odex.jl
@@ -102,10 +102,9 @@ type OdexArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   RPAR    :: Vector{Float64}   # add. double-array
   IPAR    :: Ref{OdexInternalCallInfos} # misuse IPAR
   IDID    :: Vector{FInt}      # Status code
+
     ## Allow uninitialized construction
-  function OdexArguments()
-    return new()
-  end
+    (::Type{OdexArguments{T}}){T}() = new{T}()
 end
 
 """

--- a/src/Odex.jl
+++ b/src/Odex.jl
@@ -104,6 +104,8 @@ type OdexArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   IDID    :: Vector{FInt}      # Status code
 
     ## Allow uninitialized construction
+    # This ugly syntax is only for v0.5 compatibility: after v0.5 is dropped, it should be:
+    # OdexArguments{T}() where {T} = new{T}()
     (::Type{OdexArguments{T}}){T}() = new{T}()
 end
 

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -10,6 +10,8 @@ macro import_options()
   )
 end
 
+# Work around syntax changes in v0.6 without requiring Compat
+eval(Expr(:abstract, :(AbstractOptionsODE <: Any)))
 """
   Ancestor for all types storing options for ODE-solvers.
   
@@ -22,8 +24,8 @@ end
   All types for this purpose have this abstract type as super-type.
   
   Required fields are: `name`, `lastchanged`, `options`
-  """
-abstract AbstractOptionsODE <: Any
+"""
+AbstractOptionsODE
 
 """
   Stores options for ODE-Solver(s) together with a name.

--- a/src/Radau.jl
+++ b/src/Radau.jl
@@ -152,6 +152,8 @@ type RadauArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   IDID    :: Vector{FInt}      # Status code
 
     ## Allow uninitialized construction
+    # This ugly syntax is only for v0.5 compatibility: after v0.5 is dropped, it should be:
+    # RadauArguments{T}() where {T} = new{T}()
     (::Type{RadauArguments{T}}){T}() = new{T}()
 end
 

--- a/src/Radau.jl
+++ b/src/Radau.jl
@@ -150,10 +150,9 @@ type RadauArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   RPAR    :: Vector{Float64}   # add. double-array
   IPAR    :: Ref{RadauInternalCallInfos} # misuse IPAR
   IDID    :: Vector{FInt}      # Status code
+
     ## Allow uninitialized construction
-  function RadauArguments()
-    return new()
-  end
+    (::Type{RadauArguments{T}}){T}() = new{T}()
 end
 
 

--- a/src/Rodas.jl
+++ b/src/Rodas.jl
@@ -133,10 +133,9 @@ type RodasArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   RPAR    :: Vector{Float64}   # add. double-array
   IPAR    :: Ref{RodasInternalCallInfos} # misuse IPAR
   IDID    :: Vector{FInt}      # Status code
+
     ## Allow uninitialized construction
-  function RodasArguments()
-    return new()
-  end
+    (::Type{RodasArguments{T}}){T}() = new{T}()
 end
 
 

--- a/src/Rodas.jl
+++ b/src/Rodas.jl
@@ -135,6 +135,8 @@ type RodasArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   IDID    :: Vector{FInt}      # Status code
 
     ## Allow uninitialized construction
+    # This ugly syntax is only for v0.5 compatibility: after v0.5 is dropped, it should be:
+    # RodasArguments{T}() where {T} = new{T}()
     (::Type{RodasArguments{T}}){T}() = new{T}()
 end
 

--- a/src/Seulex.jl
+++ b/src/Seulex.jl
@@ -125,10 +125,9 @@ type SeulexArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   RPAR    :: Vector{Float64}   # add. double-array
   IPAR    :: Ref{SeulexInternalCallInfos} # misuse IPAR
   IDID    :: Vector{FInt}      # Status code
+
     ## Allow uninitialized construction
-  function SeulexArguments()
-    return new()
-  end
+    (::Type{SeulexArguments{T}}){T}() = new{T}()
 end
 
 """

--- a/src/Seulex.jl
+++ b/src/Seulex.jl
@@ -127,6 +127,8 @@ type SeulexArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
   IDID    :: Vector{FInt}      # Status code
 
     ## Allow uninitialized construction
+    # This ugly syntax is only for v0.5 compatibility: after v0.5 is dropped, it should be:
+    # SeulexArguments{T}() where {T} = new{T}()
     (::Type{SeulexArguments{T}}){T}() = new{T}()
 end
 


### PR DESCRIPTION
Note: I dropped v0.4 support, so that v0.6 could be added (without deprecation warnings),
there was no way of handling the changes to the inner constructor syntax easily without doing so.
To retain v0.4 support (which JuliaDiffEq has dropped also) I think you'd need to tag a release before merging this PR, and set it up in METADATA.