### PR TITLE
Remove ::Function from dispatch

### DIFF
--- a/src/Bvpsol.jl
+++ b/src/Bvpsol.jl
@@ -71,8 +71,8 @@ bvpsol_global_cbi = nothing
               │    odesolver(rhs,t,tEnd,x,opt)            │  ⎪ IVP
               └───────────────────────────────────────────┘  ⎭
   """
-type BvpsolInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
-        BC_F<:Function, ODESOL_F<:Function} <: ODEinternalCallInfos
+type BvpsolInternalCallInfos{FInt<:FortranInt, RHS_F,
+        BC_F, ODESOL_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   # RHS:
@@ -361,7 +361,7 @@ function bvpsol_i32(rhs, bc,
 end
 
 function bvpsol_impl{FInt<:FortranInt}(rhs, bc,
-  t::Vector, x::Matrix, odesolver, 
+  t::Vector, x::Matrix, odesolver,
   opt::AbstractOptionsODE, args::BvpsolArguments{FInt})
 
   (lio,l,l_g,l_solver,lprefix) = solver_init("bvpsol",opt)

--- a/src/Call.jl
+++ b/src/Call.jl
@@ -17,7 +17,7 @@ const solvers_outputattimes = (ddeabm, ddeabm_i32, ddebdf, ddebdf_i32)
       function odecall(solver::Function, rhs::Function, t::Vector, x0::Vector,
                       opt::AbstractOptionsODE)
           -> (tVec,xVec,retcode,stats)
-  
+
   Calls `solver` with the given right-hand side `rhs`.
   There are two cases:
 
@@ -28,17 +28,17 @@ const solvers_outputattimes = (ddeabm, ddeabm_i32, ddebdf, ddebdf_i32)
   (adaptive) solver has automatically chosen. And the `xVec` has the
   states at this times. So: `tVec` is a `Vector{Float64}(m)` and
   `xVec` is a `Array{Float64}(m,length(x0))`.
-  
+
   If `2<length(t)`, then the values in `t` must be strictly ascending
   or strictly descending. Then a special output function is used to get
   the numerical solution at the given `t`-values. In this case
   `tVec` is a `Vector{Float64}(length(t))` and
   `xVec` is a `Array{Float64}(length(t),length(x0))`.
-  
+
   If in `opt` a output function is given, then this output function is
   also called/used.
   """
-function odecall(solver::Function, rhs::Function, t::Vector, x0::Vector, 
+function odecall(solver::Function, rhs, t::Vector, x0::Vector,
                  opt::AbstractOptionsODE)
   tLen = length(t)
   tLen < 2 && throw(ArgumentErrorODE(
@@ -55,7 +55,7 @@ function odecall(solver::Function, rhs::Function, t::Vector, x0::Vector,
   locopt = OptionsODE(opt)
   orig_outputfcn = getOption(opt, OPT_OUTPUTFCN, nothing)
   orig_outputmode = getOption(opt, OPT_OUTPUTMODE, OUTPUTFCN_NEVER)
-  
+
   if 2==tLen
     tVec = Vector{Float64}()    # we do not know how many steps/points
     xVec = Vector{Float64}()    # the solver will use => tVec and xVec grow
@@ -65,7 +65,7 @@ function odecall(solver::Function, rhs::Function, t::Vector, x0::Vector,
     #             NEVER   │       WODENSE
     #            WODENSE  │       WODENSE
     #             DENSE   │       DENSE
-    orig_outputmode != OUTPUTFCN_DENSE && 
+    orig_outputmode != OUTPUTFCN_DENSE &&
       setOption!(locopt,OPT_OUTPUTMODE,OUTPUTFCN_WODENSE)
 
     # save only grid points of solver in tVec, xVec
@@ -113,8 +113,8 @@ function odecall(solver::Function, rhs::Function, t::Vector, x0::Vector,
     function outputfcn_givent(reason::OUTPUTFCN_CALL_REASON,
           told::Float64, tnew::Float64, x::Vector{Float64},
           eval_sol_fcn::Function, extra_data::Dict)
-      
-      if (reason == OUTPUTFCN_CALL_STEP) 
+
+      if (reason == OUTPUTFCN_CALL_STEP)
         while (tPos ≤ tLen) &&
               ( (told ≤ t[tPos] ≤ tnew) || (told ≥ t[tPos] ≥ tnew) )
           tVec[tPos] = t[tPos]
@@ -137,9 +137,9 @@ function odecall(solver::Function, rhs::Function, t::Vector, x0::Vector,
       setOption!(locopt,OPT_OUTPUTFCN, outputfcn_givent)
     end
   end
-  
+
   (tout,xout,retcode,stats) = solver( rhs, t0, T, x0, locopt)
-  
+
   return (tVec,reshape(xVec,d,length(xVec)÷d).',retcode,stats)
 
 end

--- a/src/Colnew.jl
+++ b/src/Colnew.jl
@@ -36,13 +36,13 @@ colnew_global_cbi = nothing
 
 """
   Type encapsulating all required data for colnew-Callbacks.
-  
+
   Unfortunately colnew.f does not support passthrough arguments.
-  
+
   We have the typical calling stack:
 
   """
-type ColnewInternalCallInfos{FInt<:FortranInt, 
+type ColnewInternalCallInfos{FInt<:FortranInt,
         RHS_F<:Function, DRHS_F<:Function,
         BC_F<:Function, DBC_F<:Function,
         GUESS_F<:Function} <: ODEinternalCallInfos
@@ -120,20 +120,20 @@ function colnew_rhs{CI}(t, z, f, cbi::CI)
 end
 
 """
-        function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64}, 
+        function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64},
           f_::Ptr{Float64})
 
   This is the right-hand side given as callback to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
-function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64}, 
+function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64},
   f_::Ptr{Float64})
 
   cbi = colnew_global_cbi :: ColnewInternalCallInfos
   n = cbi.n; d = cbi.d
-  
+
   t = unsafe_load(t_)
   z = unsafe_wrap(Array, z_, (d,), false)
   f = unsafe_wrap(Array, f_, (n,), false)
@@ -143,7 +143,7 @@ function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64},
 end
 
 function unsafe_colnew_rhs_c{FInt}(fint_flag::FInt)
-  return cfunction(unsafe_colnew_rhs, Void, 
+  return cfunction(unsafe_colnew_rhs, Void,
     (Ptr{Float64}, Ptr{Float64}, Ptr{Float64}))
 end
 
@@ -169,7 +169,7 @@ end
 
   This is the Jacobian for the right-hand side given as callback to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_colnew_Drhs(t_::Ptr{Float64}, z_::Ptr{Float64},
@@ -214,7 +214,7 @@ end
   This is the side-/boundary-conditions given as callback
   to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_colnew_bc{FInt<:FortranInt}(i_::Ptr{FInt},
@@ -259,7 +259,7 @@ end
   This is the jacobian for the side-/boundary-conditions given as callback
   to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_colnew_Dbc{FInt<:FortranInt}(i_::Ptr{FInt},
@@ -298,7 +298,7 @@ end
 """
   This is the guess function given as callback to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_colnew_guess(t_::Ptr{Float64}, z_::Ptr{Float64},
@@ -376,7 +376,7 @@ end
       function rhs(t, z, f)
 
   with the input data: t (scalar) time and z∈ℝᵈ (z=z(x(t))).
-  The values of the right-hand side have to be saved in f: f∈ℝⁿ! 
+  The values of the right-hand side have to be saved in f: f∈ℝⁿ!
   Only the non-trivial parts of the right-hand side must be calculated.
 
   ## Drhs
@@ -410,7 +410,7 @@ end
       function Dbc(i, z, dbc)
 
   with the input data: integer index i and z∈ℝᵈ (z=z(x(t))).
-  The  values of the derivative of the i-th side-condition 
+  The  values of the derivative of the i-th side-condition
   (at time ζ(i)) has to be saved in dbc:
 
                 ∂bcᵢ
@@ -437,7 +437,7 @@ end
 
   ## return values
 
-  `sol` is a solution object which can be evaluated with the 
+  `sol` is a solution object which can be evaluated with the
   `evalSolution` functions. Or you can ask for the (final) grid
   of the solution with `getSolutionGrid`.
 
@@ -451,7 +451,7 @@ end
         -3: there is an input data error
 
   In `opt` the following options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -536,10 +536,10 @@ end
 
   """
 function colnew(interval::Vector, orders::Vector, ζ::Vector,
-  rhs::Function, Drhs::Function,
+  rhs, Drhs,
   bc::Function, Dbc::Function, guess, opt::AbstractOptionsODE)
 
-  return colnew_impl(interval, orders, ζ, rhs, Drhs, bc, Dbc, guess, opt, 
+  return colnew_impl(interval, orders, ζ, rhs, Drhs, bc, Dbc, guess, opt,
     ColnewArguments{Int64}(Int64(0)))
 end
 
@@ -547,17 +547,17 @@ end
   colnew with 32bit integers, see colnew.
   """
 function colnew_i32(interval::Vector, orders::Vector, ζ::Vector,
-  rhs::Function, Drhs::Function,
-  bc::Function, Dbc::Function, guess, opt::AbstractOptionsODE)
+  rhs, Drhs,
+  bc, Dbc, guess, opt::AbstractOptionsODE)
 
-  return colnew_impl(interval, orders, ζ, rhs, Drhs, bc, Dbc, guess, opt, 
+  return colnew_impl(interval, orders, ζ, rhs, Drhs, bc, Dbc, guess, opt,
     ColnewArguments{Int32}(Int32(0)))
 end
 
 function colnew_impl{FInt<:FortranInt}(
   interval::Vector, orders::Vector, ζ::Vector,
-  rhs::Function, Drhs::Function,
-  bc::Function, Dbc::Function, guess, opt::AbstractOptionsODE,
+  rhs, Drhs,
+  bc, Dbc, guess, opt::AbstractOptionsODE,
   args::ColnewArguments{FInt})
 
   (lio,l,l_g,l_solver,lprefix) = solver_init("colnew",opt)
@@ -578,7 +578,7 @@ function colnew_impl{FInt<:FortranInt}(
     t_ab = getVectorCheckLength(interval, Float64, 2)
   catch e
     throw(ArgumentErrorODE(
-      "cannot convert interval to Vector{Float64} with 2 components", 
+      "cannot convert interval to Vector{Float64} with 2 components",
       :interval, e))
   end
   t_ab[1] ≥ t_ab[2] && throw(ArgumentErrorODE(
@@ -639,7 +639,7 @@ function colnew_impl{FInt<:FortranInt}(
     # RTOL ( => ltol, tol)
     OPT = OPT_RTOL
     rtol = getOption(opt, OPT, 1e-6)
-    if isscalar(rtol) 
+    if isscalar(rtol)
       rtol = rtol*ones(Float64, d)
     end
     rtol = getVectorCheckLength(rtol, Float64, d, false)
@@ -656,7 +656,7 @@ function colnew_impl{FInt<:FortranInt}(
       "All components in RTOL were NaN!"), :opt)
     args.IPAR[4] = FInt( length(args.LTOL) )
 
-    OPT = OPT_BVPCLASS; 
+    OPT = OPT_BVPCLASS;
     bvpclass = convert(FInt, getOption(opt, OPT, 1))
     @assert 0 ≤ bvpclass ≤ 3
     args.IPAR[1] = FInt( bvpclass == 0 ? 0 : 1)
@@ -673,12 +673,12 @@ function colnew_impl{FInt<:FortranInt}(
 
     OPT = OPT_SUBINTERVALS
     subintervals = getOption(opt, OPT, 5)
-    if isscalar(subintervals) 
+    if isscalar(subintervals)
       args.IPAR[8] = FInt(0) # uniform(-like) initial grid
       args.IPAR[3] = FInt(subintervals)
       @assert 0 < args.IPAR[3] ≤ max_subintervals
     else
-      subintervals = getVectorCheckLength(subintervals, Float64, 
+      subintervals = getVectorCheckLength(subintervals, Float64,
         length(subintervals)) # always copy
       append!(subintervals, ζ)
       subintervals = unique(sort!(subintervals))
@@ -721,7 +721,7 @@ function colnew_impl{FInt<:FortranInt}(
     nsizef = 4 + 3*d + (5+kd)*kdm + (2*d-nrec)*2*d
 
     args.IPAR[5] = FInt(max_subintervals*nsizef)
-    args.IPAR[6] = FInt(max_subintervals*nsizei) 
+    args.IPAR[6] = FInt(max_subintervals*nsizei)
 
     args.FSPACE = zeros(Float64, args.IPAR[5])
     args.ISPACE = zeros(FInt, args.IPAR[6])
@@ -772,7 +772,7 @@ function colnew_impl{FInt<:FortranInt}(
   end
   cbi = nothing
   try
-    global colnew_global_cbi = cbi = ColnewInternalCallInfos(lio, l, n, d, 
+    global colnew_global_cbi = cbi = ColnewInternalCallInfos(lio, l, n, d,
       rhs, "unsafe_colnewrhs: ", 0,  Drhs, "unsafe_colnew_Drhs: ",0,
       bc, "unsafe_colnew_bc: ", 0,   Dbc, "unsafe_colnew_Dbc: ", 0,
       guess, "unsafe_colnew_guess")
@@ -816,7 +816,7 @@ function colnew_impl{FInt<:FortranInt}(
   end
   l_g && println(lio, lprefix, string("done IFALG=", args.IFLAG[1]))
   solobj = ColnewSolution(
-    method_appsln, t_ab[1], t_ab[2], n, d, 
+    method_appsln, t_ab[1], t_ab[2], n, d,
     args.ISPACE[1:(7+n)],
     args.FSPACE[1:args.ISPACE[7]])
   stats = Dict{AbstractString,Any}(
@@ -834,8 +834,8 @@ end
           t::Real, z::Array{Float64})
 
   Evaluates an already obtained solution `sol` at time `t`.
-  The values of the solution are saved in `z` which must be a 
-  vector (of length d). 
+  The values of the solution are saved in `z` which must be a
+  vector (of length d).
   `t` must be in the interval [a,b] where the problem was solved.
   """
 function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt},
@@ -853,14 +853,14 @@ function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt},
 end
 
 """
-        function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt}, 
+        function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt},
           t::Real)
 
   Evaluates an already obtained solution `sol` at time `t`.
   A newly allocated vector with the solution values is retured.
   `t` must be in the interval [a,b] where the problem was solved.
   """
-function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt}, 
+function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt},
   t::Real)
 
   z = Vector{Float64}(sol.d)
@@ -869,16 +869,16 @@ function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt},
 end
 
 """
-        function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt}, 
+        function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt},
           t::Vector)
 
   Evaluates an already obtained solution `sol` at time all
   times in the vector `t`.
-  A newly allocated matrix of size `(length(t), d)` with the solution 
+  A newly allocated matrix of size `(length(t), d)` with the solution
   values is retured.
   All values of `t` must be in the interval [a,b] where the problem was solved.
   """
-function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt}, 
+function evalSolution{FInt<:FortranInt}(sol::ColnewSolution{FInt},
   t::Vector)
 
   tno = length(t)
@@ -902,7 +902,7 @@ function getSolutionGrid{FInt<:FortranInt}(sol::ColnewSolution{FInt})
 end
 
 
-"""  
+"""
   ## Compile COLNEW
 
   The julia ODEInterface tries to compile and link the solvers
@@ -911,37 +911,37 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
+
        https://people.sc.fsu.edu/~jburkardt/f77_src/colnew/colnew.html
-  
+
   See `help_colnew_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile BVPSOL with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o colnew.o colnew.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
        gfortran -shared -fPIC -o colnew.so colnew.o
        gfortran -shared -fPIC -o colnew.dylib colnew.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile BVPSOL with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o colnew.o colnew.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
+
        gfortran -shared -o colnew.dll colnew.o
   """
 function help_colnew_compile()
@@ -958,104 +958,104 @@ end
   ```
                    GNU LESSER GENERAL PUBLIC LICENSE
                          Version 3, 29 June 2007
-  
+
    Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
    Everyone is permitted to copy and distribute verbatim copies
    of this license document, but changing it is not allowed.
-  
-  
+
+
     This version of the GNU Lesser General Public License incorporates
   the terms and conditions of version 3 of the GNU General Public
   License, supplemented by the additional permissions listed below.
-  
+
     0. Additional Definitions.
-  
+
     As used herein, "this License" refers to version 3 of the GNU Lesser
   General Public License, and the "GNU GPL" refers to version 3 of the GNU
   General Public License.
-  
+
     "The Library" refers to a covered work governed by this License,
   other than an Application or a Combined Work as defined below.
-  
+
     An "Application" is any work that makes use of an interface provided
   by the Library, but which is not otherwise based on the Library.
   Defining a subclass of a class defined by the Library is deemed a mode
   of using an interface provided by the Library.
-  
+
     A "Combined Work" is a work produced by combining or linking an
   Application with the Library.  The particular version of the Library
   with which the Combined Work was made is also called the "Linked
   Version".
-  
+
     The "Minimal Corresponding Source" for a Combined Work means the
   Corresponding Source for the Combined Work, excluding any source code
   for portions of the Combined Work that, considered in isolation, are
   based on the Application, and not on the Linked Version.
-  
+
     The "Corresponding Application Code" for a Combined Work means the
   object code and/or source code for the Application, including any data
   and utility programs needed for reproducing the Combined Work from the
   Application, but excluding the System Libraries of the Combined Work.
-  
+
     1. Exception to Section 3 of the GNU GPL.
-  
+
     You may convey a covered work under sections 3 and 4 of this License
   without being bound by section 3 of the GNU GPL.
-  
+
     2. Conveying Modified Versions.
-  
+
     If you modify a copy of the Library, and, in your modifications, a
   facility refers to a function or data to be supplied by an Application
   that uses the facility (other than as an argument passed when the
   facility is invoked), then you may convey a copy of the modified
   version:
-  
+
      a) under this License, provided that you make a good faith effort to
      ensure that, in the event an Application does not supply the
      function or data, the facility still operates, and performs
      whatever part of its purpose remains meaningful, or
-  
+
      b) under the GNU GPL, with none of the additional permissions of
      this License applicable to that copy.
-  
+
     3. Object Code Incorporating Material from Library Header Files.
-  
+
     The object code form of an Application may incorporate material from
   a header file that is part of the Library.  You may convey such object
   code under terms of your choice, provided that, if the incorporated
   material is not limited to numerical parameters, data structure
   layouts and accessors, or small macros, inline functions and templates
   (ten or fewer lines in length), you do both of the following:
-  
+
      a) Give prominent notice with each copy of the object code that the
      Library is used in it and that the Library and its use are
      covered by this License.
-  
+
      b) Accompany the object code with a copy of the GNU GPL and this license
      document.
-  
+
     4. Combined Works.
-  
+
     You may convey a Combined Work under terms of your choice that,
   taken together, effectively do not restrict modification of the
   portions of the Library contained in the Combined Work and reverse
   engineering for debugging such modifications, if you also do each of
   the following:
-  
+
      a) Give prominent notice with each copy of the Combined Work that
      the Library is used in it and that the Library and its use are
      covered by this License.
-  
+
      b) Accompany the Combined Work with a copy of the GNU GPL and this license
      document.
-  
+
      c) For a Combined Work that displays copyright notices during
      execution, include the copyright notice for the Library among
      these notices, as well as a reference directing the user to the
      copies of the GNU GPL and this license document.
-  
+
      d) Do one of the following:
-  
+
          0) Convey the Minimal Corresponding Source under the terms of this
          License, and the Corresponding Application Code in a form
          suitable for, and under terms that permit, the user to
@@ -1063,14 +1063,14 @@ end
          the Linked Version to produce a modified Combined Work, in the
          manner specified by section 6 of the GNU GPL for conveying
          Corresponding Source.
-  
+
          1) Use a suitable shared library mechanism for linking with the
          Library.  A suitable mechanism is one that (a) uses at run time
          a copy of the Library already present on the user's computer
          system, and (b) will operate properly with a modified version
          of the Library that is interface-compatible with the Linked
          Version.
-  
+
      e) Provide Installation Information, but only if you would otherwise
      be required to provide such information under section 6 of the
      GNU GPL, and only to the extent that such information is
@@ -1082,30 +1082,30 @@ end
      Code. If you use option 4d1, you must provide the Installation
      Information in the manner specified by section 6 of the GNU GPL
      for conveying Corresponding Source.)
-  
+
     5. Combined Libraries.
-  
+
     You may place library facilities that are a work based on the
   Library side by side in a single library together with other library
   facilities that are not Applications and are not covered by this
   License, and convey such a combined library under terms of your
   choice, if you do both of the following:
-  
+
      a) Accompany the combined library with a copy of the same work based
      on the Library, uncombined with any other library facilities,
      conveyed under the terms of this License.
-  
+
      b) Give prominent notice with the combined library that part of it
      is a work based on the Library, and explaining where to find the
      accompanying uncombined form of the same work.
-  
+
     6. Revised Versions of the GNU Lesser General Public License.
-  
+
     The Free Software Foundation may publish revised and/or new versions
   of the GNU Lesser General Public License from time to time. Such new
   versions will be similar in spirit to the present version, but may
   differ in detail to address new problems or concerns.
-  
+
     Each version is given a distinguishing version number. If the
   Library as you received it specifies that a certain numbered version
   of the GNU Lesser General Public License "or any later version"
@@ -1115,14 +1115,14 @@ end
   received it does not specify a version number of the GNU Lesser
   General Public License, you may choose any version of the GNU Lesser
   General Public License ever published by the Free Software Foundation.
-  
+
     If the Library as you received it specifies that a proxy can decide
   whether future versions of the GNU Lesser General Public License shall
   apply, that proxy's public statement of acceptance of any version is
   permanent authorization for you to choose that version for the
   Library.
   ```
-  
+
   """
 function help_colnew_license()
   return Docs.doc(help_colnew_license)
@@ -1132,9 +1132,9 @@ end
 push!(solverInfo,
   SolverInfo("colnew",
     "Multi-Point boundary value solver for mixed order systems with collocation",
-    tuple( :OPT_BVPCLASS, :OPT_RTOL, :OPT_COLLOCATIONPTS, 
-           :OPT_SUBINTERVALS, :OPT_FREEZEINTERVALS, 
-           :OPT_ADDGRIDPOINTS, :OPT_MAXSUBINTERVALS, 
+    tuple( :OPT_BVPCLASS, :OPT_RTOL, :OPT_COLLOCATIONPTS,
+           :OPT_SUBINTERVALS, :OPT_FREEZEINTERVALS,
+           :OPT_ADDGRIDPOINTS, :OPT_MAXSUBINTERVALS,
            :OPT_DIAGNOSTICOUTPUT, :OPT_COARSEGUESSGRID,
           ),
     tuple(
@@ -1154,4 +1154,3 @@ push!(solverInfo,
 
 
 # vim:syn=julia:cc=79:fdm=indent:
-

--- a/src/Colnew.jl
+++ b/src/Colnew.jl
@@ -43,9 +43,9 @@ colnew_global_cbi = nothing
 
   """
 type ColnewInternalCallInfos{FInt<:FortranInt,
-        RHS_F<:Function, DRHS_F<:Function,
-        BC_F<:Function, DBC_F<:Function,
-        GUESS_F<:Function} <: ODEinternalCallInfos
+        RHS_F, DRHS_F,
+        BC_F, DBC_F,
+        GUESS_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   n            :: FInt                  # number of ODEs

--- a/src/Deabm.jl
+++ b/src/Deabm.jl
@@ -48,7 +48,7 @@ end
   see also help of `ODEInterface.SLATEC_continuation_call`.
   """
 type DdeabmInternalCallInfos{FInt<:FortranInt,
-        RHS_F<:Function, OUT_F<:Function} <: ODEinternalCallInfos
+        RHS_F, OUT_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   # RHS:

--- a/src/Deabm.jl
+++ b/src/Deabm.jl
@@ -53,7 +53,7 @@ type DdeabmInternalCallInfos{FInt<:FortranInt,
   loglevel     :: UInt64                # log level
   # RHS:
   N            :: FInt                  # Dimension of Problem
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   rhs_count    :: Int                   # count: number of calls to rhs
@@ -156,10 +156,10 @@ end
       ║                 │ The value will be rounded up to a        │         ║
       ║                 │ multiple of 500.                         │         ║
       ║                 │ OPT_MAXSTEPS > 0                         │         ║
-      ╚═════════════════╧══════════════════════════════════════════╧═════════╝ 
+      ╚═════════════════╧══════════════════════════════════════════╧═════════╝
 
   """
-function ddeabm(rhs::Function, t0::Real, T::Real,
+function ddeabm(rhs, t0::Real, T::Real,
                   x0::Vector, opt::AbstractOptionsODE)
   return ddeabm_impl(rhs, t0, T, x0, opt, DdeabmArguments{Int64}(Int64(0)))
 end
@@ -167,7 +167,7 @@ end
 """
   ddeabm with 32bit integers, see ddeabm.
   """
-function ddeabm_i32(rhs::Function, t0::Real, T::Real,
+function ddeabm_i32(rhs, t0::Real, T::Real,
                   x0::Vector, opt::AbstractOptionsODE)
   return ddeabm_impl(rhs, t0, T, x0, opt, DdeabmArguments{Int32}(Int32(0)))
 end
@@ -178,10 +178,10 @@ end
 const ddeabm_maxnum = 500
 
 """
-       function ddeabm_impl{FInt<:FortranInt}(rhs::Function, 
-                t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+       function ddeabm_impl{FInt<:FortranInt}(rhs::Function,
+                t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
                 args::DdeabmArguments{FInt})
-  
+
   implementation of ddeabm-call for FInt.
 
   This solver has the conecpt of continuation calls (CC), see
@@ -205,11 +205,11 @@ const ddeabm_maxnum = 500
       ║ OUTPUTFCN_WODENSE │ given vector      │ no   INFO(3)=0     │  C3     ║
       ╠═══════════════════╪═══════════════════╧════════════════════╧═════════╣
       ║ OUTPUTFCN_DENSE   │        N O T    S U P P O R T E D !              ║
-      ╚═══════════════════╧══════════════════════════════════════════════════╝ 
+      ╚═══════════════════╧══════════════════════════════════════════════════╝
 
   """
-function ddeabm_impl{FInt<:FortranInt}(rhs::Function, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function ddeabm_impl{FInt<:FortranInt}(rhs,
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::DdeabmArguments{FInt})
 
   (lio,l,l_g,l_solver,lprefix) = solver_start("ddeabm",rhs,t0,T,x0,opt)
@@ -268,7 +268,7 @@ function ddeabm_impl{FInt<:FortranInt}(rhs::Function,
   args.INFO[3] = (case == 2) ? 1 : 0
   retcode = -100
 
-  cbi = DdeabmInternalCallInfos(lio, l, d, rhs, rhs_mode, rhs_lprefix, 
+  cbi = DdeabmInternalCallInfos(lio, l, d, rhs, rhs_mode, rhs_lprefix,
         0, output_mode, output_fcn, Dict())
 
   args.FCN = unsafe_SLATEC1RHSCallback_c(cbi, FInt(0))
@@ -287,7 +287,7 @@ function ddeabm_impl{FInt<:FortranInt}(rhs::Function,
   end
 
   maxsteps_seen = 0
-  while (true) 
+  while (true)
     told = args.t[1]
     args.tEnd[1] = t_values[1]
     ccall( method_ddeabm, Void,
@@ -379,13 +379,13 @@ end
   See `help_ddeabm_license` for the licsense information.
 
   ### Using `gfortran` and 64bit integers (Linux, Mac and Windows)
-  
+
   Here is an example how to compile DDEABM with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fPIC -fdefault-integer-8 
+       gfortran -c -fPIC -fdefault-integer-8
                 -fdefault-real-8 -fdefault-double-8 -o slatec.o slatec.f
-       gfortran -c -fPIC -fdefault-integer-8 
+       gfortran -c -fPIC -fdefault-integer-8
                 -fdefault-real-8 -fdefault-double-8 -o ddeabm.o ddeabm.f
 
   In order to get create a shared library (from the object file above) use
@@ -410,7 +410,7 @@ end
 push!(solverInfo,
   SolverInfo("ddeabm",
     "Adams-Bashforth-Moulton Predictor-Corrector method (orders: 1-12)",
-    tuple(:OPT_RTOL, :OPT_ATOL, :OPT_RHS_CALLMODE, 
+    tuple(:OPT_RTOL, :OPT_ATOL, :OPT_RHS_CALLMODE,
           :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_OUTPUTATTIMES,
           :OPT_TSTOP, :OPT_MAXSTEPS,

--- a/src/Debdf.jl
+++ b/src/Debdf.jl
@@ -58,7 +58,7 @@ type DdebdfInternalCallInfos{FInt<:FortranInt,
   loglevel     :: UInt64                # log level
   # RHS:
   N            :: FInt                  # Dimension of Problem
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   rhs_count    :: Int                   # count: number of calls to rhs
@@ -189,10 +189,10 @@ end
       ║                 │ the Jacobian matrix is banded and the    │         ║
       ║                 │ code is told this.                       │         ║
       ║                 │ see also help of BandedMatrix            │         ║
-      ╚═════════════════╧══════════════════════════════════════════╧═════════╝ 
+      ╚═════════════════╧══════════════════════════════════════════╧═════════╝
 
   """
-function ddebdf(rhs::Function, t0::Real, T::Real,
+function ddebdf(rhs, t0::Real, T::Real,
                   x0::Vector, opt::AbstractOptionsODE)
   return ddebdf_impl(rhs, t0, T, x0, opt, DdebdfArguments{Int64}(Int64(0)))
 end
@@ -200,7 +200,7 @@ end
 """
   ddebdf with 32bit integers, see ddebdf.
   """
-function ddebdf_i32(rhs::Function, t0::Real, T::Real,
+function ddebdf_i32(rhs, t0::Real, T::Real,
                   x0::Vector, opt::AbstractOptionsODE)
   return ddebdf_impl(rhs, t0, T, x0, opt, DdebdfArguments{Int32}(Int32(0)))
 end
@@ -211,10 +211,10 @@ end
 const ddebdf_maxnum = 500
 
 """
-       function ddebdf_impl{FInt<:FortranInt}(rhs::Function, 
-                t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+       function ddebdf_impl{FInt<:FortranInt}(rhs::Function,
+                t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
                 args::DdebdfArguments{FInt})
-  
+
   implementation of ddebdf-call for FInt.
 
   This solver has the conecpt of continuation calls (CC), see
@@ -238,11 +238,11 @@ const ddebdf_maxnum = 500
       ║ OUTPUTFCN_WODENSE │ given vector      │ no   INFO(3)=0     │  C3     ║
       ╠═══════════════════╪═══════════════════╧════════════════════╧═════════╣
       ║ OUTPUTFCN_DENSE   │        N O T    S U P P O R T E D !              ║
-      ╚═══════════════════╧══════════════════════════════════════════════════╝ 
+      ╚═══════════════════╧══════════════════════════════════════════════════╝
 
   """
-function ddebdf_impl{FInt<:FortranInt}(rhs::Function, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function ddebdf_impl{FInt<:FortranInt}(rhs, 
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::DdebdfArguments{FInt})
 
   (lio,l,l_g,l_solver,lprefix) = solver_start("ddebdf",rhs,t0,T,x0,opt)
@@ -261,8 +261,8 @@ function ddebdf_impl{FInt<:FortranInt}(rhs::Function,
   args.INFO = zeros(FInt, 15)
 
   # RWORK
-  args.LRW = [ FInt( 
-    jacobibandstruct == nothing ? 
+  args.LRW = [ FInt(
+    jacobibandstruct == nothing ?
       250+10*d+d*d : 250+10*d+(2*jacobibandstruct[1]+jacobibandstruct[2]+1)*d
     ) ]
   args.RWORK = zeros(Float64, args.LRW[1])
@@ -317,7 +317,7 @@ function ddebdf_impl{FInt<:FortranInt}(rhs::Function,
   retcode = -100
 
   cbi = DdebdfInternalCallInfos(lio, l, d, rhs, rhs_mode, rhs_lprefix,
-        0, output_mode, output_fcn, Dict(), 
+        0, output_mode, output_fcn, Dict(),
         jacobimatrix == nothing ? dummy_func : jacobimatrix,
         jacobibandstruct, jac_lprefix, 0, get_view_function())
 
@@ -433,13 +433,13 @@ end
   See `help_ddebdf_license` for the licsense information.
 
   ### Using `gfortran` and 64bit integers (Linux, Mac and Windows)
-  
+
   Here is an example how to compile DDEBDF with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fPIC -fdefault-integer-8 
+       gfortran -c -fPIC -fdefault-integer-8
                 -fdefault-real-8 -fdefault-double-8 -o slatec.o slatec.f
-       gfortran -c -fPIC -fdefault-integer-8 
+       gfortran -c -fPIC -fdefault-integer-8
                 -fdefault-real-8 -fdefault-double-8 -o ddebdf.o ddbdfm.f
 
   In order to get create a shared library (from the object file above) use
@@ -463,7 +463,7 @@ end
 push!(solverInfo,
   SolverInfo("ddebdf",
     "Backward Differentiation Formula (orders: 1-5)",
-    tuple(:OPT_RTOL, :OPT_ATOL, :OPT_RHS_CALLMODE, 
+    tuple(:OPT_RTOL, :OPT_ATOL, :OPT_RHS_CALLMODE,
           :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_OUTPUTATTIMES,
           :OPT_TSTOP, :OPT_MAXSTEPS,

--- a/src/Debdf.jl
+++ b/src/Debdf.jl
@@ -52,8 +52,8 @@ end
   see also help of `ODEInterface.SLATEC_continuation_call`.
   """
 type DdebdfInternalCallInfos{FInt<:FortranInt,
-        RHS_F<:Function, OUT_F<:Function,
-        JAC_F<:Function, VIEW_F<:Function} <: ODEinternalCallInfos
+        RHS_F, OUT_F,
+        JAC_F, VIEW_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   # RHS:
@@ -241,7 +241,7 @@ const ddebdf_maxnum = 500
       ╚═══════════════════╧══════════════════════════════════════════════════╝
 
   """
-function ddebdf_impl{FInt<:FortranInt}(rhs, 
+function ddebdf_impl{FInt<:FortranInt}(rhs,
         t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::DdebdfArguments{FInt})
 

--- a/src/Dopri.jl
+++ b/src/Dopri.jl
@@ -2,7 +2,7 @@
 
 """
   Type encapsulating all required data for Dopri-Solver-Callbacks.
-  
+
   We have the typical calling stack:
 
        dopri5/dop853
@@ -23,12 +23,12 @@
            call_julia_output_fcn(  ... DONE ... )
                output_fcn ( ... DONE ...)
   """
-type DopriInternalCallInfos{FInt<:FortranInt, 
-        RHS_F<:Function, OUT_F<:Function} <: ODEinternalCallInfos
+type DopriInternalCallInfos{FInt<:FortranInt,
+        RHS_F, OUT_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   # RHS:
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   # SOLOUT & output function
@@ -49,11 +49,11 @@ type DopriInternalCallInfos{FInt<:FortranInt,
 end
 
 """
-       type DopriArguments{FInt<:FortranInt} <: 
+       type DopriArguments{FInt<:FortranInt} <:
                 AbstractArgumentsODESolver{FInt}
-  
+
   Stores Arguments for Dopri solver.
-  
+
   FInt is the Integer type used for the fortran compilation.
   """
 type DopriArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
@@ -86,9 +86,9 @@ end
         function create_dopri_eval_sol_fcn_closure
                 {FInt<:FortranInt, CI<:DopriInternalCallInfos}
                 (cbi::CI, d::FInt, method_contd::Ptr{Void})
-  
+
   generates a eval_sol_fcn for dopri5 and dop853.
-  
+
   Why is a closure needed? We need a function `eval_sol_fcn`
   that calls `CONTD5_` or `CONTD8_` (with `ccall`).
   But `CONTD?_` needs the informations for the current state. This
@@ -96,7 +96,7 @@ end
   `DopriInternalCallInfos`. `eval_sol_fcn` needs to get this informations.
   Here comes `create_dopri_eval_sol_fcn_closure` into play: this function
   takes the call-informations and generates a `eval_sol_fcn` with this data.
-  
+
   Why doesn't `unsafe_dopriSoloutCallback` generate a closure (then
   the current state needs not to be saved in `DopriInternalCallInfos`)?
   Because then every call to `unsafe_dopriSoloutCallback` would have
@@ -106,10 +106,10 @@ end
 
   For the typical calling sequence, see `DopriInternalCallInfos`.
   """
-function create_dopri_eval_sol_fcn_closure{FInt<:FortranInt, 
+function create_dopri_eval_sol_fcn_closure{FInt<:FortranInt,
         CI<:DopriInternalCallInfos}(
         cbi::CI, d::FInt, method_contd::Ptr{Void})
-  
+
   function eval_sol_fcn_closure(s::Float64)
     (lio,l,lprefix)=(cbi.logio,cbi.loglevel,cbi.eval_lprefix)
     l_eval = l & LOG_EVALSOL>0
@@ -128,7 +128,7 @@ function create_dopri_eval_sol_fcn_closure{FInt<:FortranInt,
           cbi.cont_i,cbi.cont_s, cbi.cont_con, cbi.cont_icomp, cbi.cont_nd)
       end
     end
-    
+
     l_eval && println(lio,lprefix,"contd returned ",result)
     return result
   end
@@ -138,46 +138,46 @@ end
 """
         function unsafe_dopriSoloutCallback
                 {FInt<:FortranInt, CI<:DopriInternalCallInfos}
-                (nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
+                (nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
                 x_::Ptr{Float64}, n_::Ptr{FInt}, con_::Ptr{Float64},
-                icomp_::Ptr{FInt}, nd_::Ptr{FInt}, rpar_::Ptr{Float64}, 
+                icomp_::Ptr{FInt}, nd_::Ptr{FInt}, rpar_::Ptr{Float64},
                 cbi::CI, irtrn_::Ptr{FInt})
-  
+
   This is the solout given as callback to Fortran-dopri.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
 
   This function saves the state informations of the solver in
   `DopriInternalCallInfos`, where they can be found by
   the `eval_sol_fcn`, see `create_dopri_eval_sol_fcn_closure`.
-  
+
   Then the user-supplied `output_fcn` is called (which in turn can use
   `eval_sol_fcn`, to evalutate the solution at intermediate points).
-  
-  The return value of the `output_fcn` is propagated to 
+
+  The return value of the `output_fcn` is propagated to
   `DOPRI5_` or `DOP853_`.
-  
+
   For the typical calling sequence, see `DopriInternalCallInfos`.
   """
-function unsafe_dopriSoloutCallback{FInt<:FortranInt, 
+function unsafe_dopriSoloutCallback{FInt<:FortranInt,
         CI<:DopriInternalCallInfos}(
-        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
+        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
         x_::Ptr{Float64}, n_::Ptr{FInt}, con_::Ptr{Float64},
-        icomp_::Ptr{FInt}, nd_::Ptr{FInt}, rpar_::Ptr{Float64}, 
+        icomp_::Ptr{FInt}, nd_::Ptr{FInt}, rpar_::Ptr{Float64},
         cbi::CI, irtrn_::Ptr{FInt})
 
   nr = unsafe_load(nr_); told = unsafe_load(told_); t = unsafe_load(t_)
   n = unsafe_load(n_)
   x = unsafe_wrap(Array, x_,(n,),false)
   irtrn = unsafe_wrap(Array, irtrn_,(1,),false)
-  
+
   (lio,l,lprefix)=(cbi.logio,cbi.loglevel,cbi.out_lprefix)
   l_sol = l & LOG_SOLOUT>0
 
   l_sol && println(lio,lprefix,"called with nr=",nr," told=",told,
                                " t=",t," x=",x)
-  
+
   cbi.tOld = told; cbi.tNew = t; cbi.xNew = x;
   cbi.cont_con = con_; cbi.cont_icomp = icomp_; cbi.cont_nd = nd_;
   cbi.output_data["nr"] = nr
@@ -204,32 +204,32 @@ end
           -> C-callable function pointer
   """
 function unsafe_dopriSoloutCallback_c{FInt,CI}(cbi::CI, fint_flag::FInt)
-  return cfunction(unsafe_dopriSoloutCallback, Void, (Ptr{FInt}, 
-    Ptr{Float64}, Ptr{Float64},Ptr{Float64}, 
+  return cfunction(unsafe_dopriSoloutCallback, Void, (Ptr{FInt},
+    Ptr{Float64}, Ptr{Float64},Ptr{Float64},
     Ptr{FInt}, Ptr{Float64},
-    Ptr{FInt}, Ptr{FInt}, Ptr{Float64}, 
+    Ptr{FInt}, Ptr{FInt}, Ptr{Float64},
     Ref{CI}, Ptr{FInt}))
 end
 
 """
         function dopri_extract_commonOpt{FInt<:FortranInt}(
-                t0::Real, T::Real, x0::Vector, 
+                t0::Real, T::Real, x0::Vector,
                 opt::AbstractOptionsODE, args::DopriArguments{FInt})
              -> (d,nrdense,rhs_mode,output_mode,output_fcn)
-  
-  calls solver_extract_commonOpt and additionally sets args.ITOL, args.IOUT 
+
+  calls solver_extract_commonOpt and additionally sets args.ITOL, args.IOUT
   """
 function dopri_extract_commonOpt{FInt<:FortranInt}(
-        t0::Real, T::Real, x0::Vector, 
+        t0::Real, T::Real, x0::Vector,
         opt::AbstractOptionsODE, args::DopriArguments{FInt})
-  
+
   (d,nrdense,scalarFlag,rhs_mode,output_mode,output_fcn) =
     solver_extract_commonOpt(t0,T,x0,opt,args)
 
   args.ITOL = [ scalarFlag?0:1 ]
   args.IOUT = [ FInt( output_mode == OUTPUTFCN_NEVER? 0:
                      (output_mode == OUTPUTFCN_DENSE?2:1) )]
-  
+
   return (d,nrdense,rhs_mode,output_mode,output_fcn)
 end
 

--- a/src/Dopri5.jl
+++ b/src/Dopri5.jl
@@ -31,7 +31,7 @@ end
       function dopri5(rhs::Function, t0::Real, T::Real,
                       x0::Vector, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
-  
+
   `retcode` can have the following values:
 
         1: computation successful
@@ -40,7 +40,7 @@ end
        -2: larger OPT_MAXSTEPS is needed
        -3: step size becomes too small
        -4: problem is probably stiff (interrupted)
-  
+
   main call for using Fortran-dopri5 solver. In `opt` the following
   options are used:
 
@@ -94,10 +94,10 @@ end
       ║ INITIALSS       │ initial step size                        │     0.0 ║
       ║                 │ if OPT_INITIALSS == 0 then a initial     │         ║
       ║                 │ guess is computed                        │         ║
-      ╚═════════════════╧══════════════════════════════════════════╧═════════╝ 
-  
+      ╚═════════════════╧══════════════════════════════════════════╧═════════╝
+
   """
-function dopri5(rhs::Function, t0::Real, T::Real,
+function dopri5(rhs, t0::Real, T::Real,
                 x0::Vector, opt::AbstractOptionsODE)
   return dopri5_impl(rhs,t0,T,x0,opt,DopriArguments{Int64}(Int64(0)))
 end
@@ -105,28 +105,28 @@ end
 """
   dopri5 with 32bit integers, see dopri5
   """
-function dopri5_i32(rhs::Function, t0::Real, T::Real,
+function dopri5_i32(rhs, t0::Real, T::Real,
                 x0::Vector, opt::AbstractOptionsODE)
   return dopri5_impl(rhs,t0,T,x0,opt,DopriArguments{Int32}(Int32(0)))
 end
 
 """
-        function dopri5_impl{FInt<:FortranInt}(rhs::Function, 
-                t0::Real, T::Real, x0::Vector, 
+        function dopri5_impl{FInt<:FortranInt}(rhs::Function,
+                t0::Real, T::Real, x0::Vector,
                 opt::AbstractOptionsODE, args::DopriArguments{FInt})
-  
+
   implementation of dopri5 for FInt.
   """
-function dopri5_impl{FInt<:FortranInt}(rhs::Function, 
-        t0::Real, T::Real, x0::Vector, 
+function dopri5_impl{FInt<:FortranInt}(rhs, 
+        t0::Real, T::Real, x0::Vector,
         opt::AbstractOptionsODE, args::DopriArguments{FInt})
-  
+
   (lio,l,l_g,l_solver,lprefix) = solver_start("dopri5",rhs,t0,T,x0,opt)
 
   (method_dopri5,method_contd5) = getAllMethodPtrs(
      (FInt == Int64)? DL_DOPRI5 : DL_DOPRI5_I32 )
 
-  (d,nrdense,rhs_mode,output_mode,output_fcn) = 
+  (d,nrdense,rhs_mode,output_mode,output_fcn) =
     dopri_extract_commonOpt(t0,T,x0,opt,args)
 
   # WORK memory
@@ -209,12 +209,12 @@ function dopri5_impl{FInt<:FortranInt}(rhs::Function,
      Ptr{Void}, Ptr{FInt},                      # Soloutfunc, IOUT
      Ptr{Float64}, Ptr{FInt},                   # WORK, LWORK
      Ptr{FInt}, Ptr{FInt},                      # IWORK, LIWORK
-     Ptr{Float64}, Ref{DopriInternalCallInfos}, # RPAR, IPAR, 
+     Ptr{Float64}, Ref{DopriInternalCallInfos}, # RPAR, IPAR,
      Ptr{FInt},                                 # IDID
     ),
-    args.N, args.FCN, 
+    args.N, args.FCN,
     args.t, args.x, args.tEnd,
-    args.RTOL, args.ATOL, args.ITOL, 
+    args.RTOL, args.ATOL, args.ITOL,
     args.SOLOUT, args.IOUT,
     args.WORK, args.LWORK,
     args.IWORK, args.LIWORK,
@@ -241,8 +241,8 @@ function dopri5_impl{FInt<:FortranInt}(rhs::Function,
   return ( args.t[1], args.x, args.IDID[1], stats)
 end
 
-"""  
-  ## Compile DOPRI5 
+"""
+  ## Compile DOPRI5
 
   The julia ODEInterface tries to compile and link the solvers
   automatically at the build-time of this module. The following
@@ -250,67 +250,67 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_dopri5_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile DOPRI5 with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dopri5.o dopri5.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
+
        gfortran -shared -fPIC -o dopri5.so dopri5.o
        gfortran -shared -fPIC -o dopri5.dylib dopri5.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile DOPRI5 with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dopri5.o dopri5.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
+
        gfortran -shared -o dopri5.dll dopri5.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile DOPRI5 with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC  
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC
+                -fdefault-real-8 -fdefault-double-8
                 -o dopri5_i32.o   dopri5.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
        gfortran -shared -fPIC -o dopri5_i32.so dopri5_i32.o
        gfortran -shared -fPIC -o dopri5_i32.dylib dopri5_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile DOPRI5 with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
+
        gfortran -c
-                -fdefault-real-8 -fdefault-double-8 
+                -fdefault-real-8 -fdefault-double-8
                 -o dopri5_i32.o   dopri5.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o dopri5_i32.dll dopri5_i32.o
-  
+
   """
 function help_dopri5_compile()
   return Docs.doc(help_dopri5_compile)
@@ -326,10 +326,10 @@ end
 push!(solverInfo,
   SolverInfo("dopri5",
     "Runge-Kutta method of order 5(4) due to Dormand & Prince",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
-          :OPT_MAXSTEPS, :OPT_STEST, :OPT_EPS, :OPT_RHO, 
-          :OPT_SSMINSEL, :OPT_SSMAXSEL, :OPT_SSBETA, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
+          :OPT_MAXSTEPS, :OPT_STEST, :OPT_EPS, :OPT_RHO,
+          :OPT_SSMINSEL, :OPT_SSMAXSEL, :OPT_SSBETA,
           :OPT_MAXSS, :OPT_INITIALSS),
     tuple(
       SolverVariant("dopri5_i64",

--- a/src/Odex.jl
+++ b/src/Odex.jl
@@ -29,7 +29,7 @@ end
 
 """
   Type encapsulating all required data for Odex-Solver-Callbacks.
-  
+
   We have the typical calling stack:
 
        odex
@@ -55,7 +55,7 @@ type OdexInternalCallInfos{FInt<:FortranInt,
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   # RHS:
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   # SOLOUT & output function
@@ -63,7 +63,7 @@ type OdexInternalCallInfos{FInt<:FortranInt,
   output_fcn   :: OUT_F                 # the output function to call
   output_data  :: Dict                  # extra_data for output_fcn
   out_lprefix  :: AbstractString        # saved log-prefix for solout
-  eval_sol_fcn :: Function              # eval_sol_fcn 
+  eval_sol_fcn :: Function              # eval_sol_fcn
   eval_lprefix :: AbstractString        # saved log-prefix for eval_sol
   tOld         :: Float64               # tOld and
   tNew         :: Float64               # tNew and
@@ -78,9 +78,9 @@ end
 
 """
        type OdexArguments{FInt} <: AbstractArgumentsODESolver{FInt}
-  
+
   Stores Arguments for Odex solver.
-  
+
   FInt is the Integer type used for the fortran compilation.
   """
 type OdexArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
@@ -113,34 +113,34 @@ end
 """
         function unsafe_odexSoloutCallback{FInt<:FortranInt,
                 CI<:OdexInternalCallInfos}(
-                nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-                x_::Ptr{Float64}, n_::Ptr{FInt}, con_::Ptr{Float64}, 
-                ncon_::Ptr{FInt}, icomp_::Ptr{FInt}, nd_::Ptr{FInt}, 
+                nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+                x_::Ptr{Float64}, n_::Ptr{FInt}, con_::Ptr{Float64},
+                ncon_::Ptr{FInt}, icomp_::Ptr{FInt}, nd_::Ptr{FInt},
                 rpar_::Ptr{Float64}, cbi::CI, irtrn_::Ptr{FInt})
-  
+
   This is the solout given as callback to Fortran-odex.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
 
   This function saves the state informations of the solver in
   `OdexInternalCallInfos`, where they can be found by
   the `eval_sol_fcn`, see `create_odex_eval_sol_fcn_closure`.
-  
+
   Then the user-supplied `output_fcn` is called (which in turn can use
   `eval_sol_fcn`, to evalutate the solution at intermediate points).
-  
+
   The return value of the `output_fcn` is propagated to `ODEX_`.
-  
+
   For the typical calling sequence, see `OdexInternalCallInfos`.
   """
 function unsafe_odexSoloutCallback{FInt<:FortranInt,
         CI<:OdexInternalCallInfos}(
-        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-        x_::Ptr{Float64}, n_::Ptr{FInt}, con_::Ptr{Float64}, 
-        ncon_::Ptr{FInt}, icomp_::Ptr{FInt}, nd_::Ptr{FInt}, 
+        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+        x_::Ptr{Float64}, n_::Ptr{FInt}, con_::Ptr{Float64},
+        ncon_::Ptr{FInt}, icomp_::Ptr{FInt}, nd_::Ptr{FInt},
         rpar_::Ptr{Float64}, cbi::CI, irtrn_::Ptr{FInt})
-  
+
   nr = unsafe_load(nr_); told = unsafe_load(told_); t = unsafe_load(t_)
   n = unsafe_load(n_)
   x = unsafe_wrap(Array, x_,(n,),false)
@@ -151,12 +151,12 @@ function unsafe_odexSoloutCallback{FInt<:FortranInt,
 
   l_sol && println(lio,lprefix,"called with nr=",nr," told=",told,
                                " t=",t," x=",x)
-  
+
   cbi.tOld = told; cbi.tNew = t; cbi.xNew = x;
   cbi.cont_con = con_; cbi.cont_ncon = ncon_; cbi.cont_icomp = icomp_;
   cbi.cont_nd = nd_;
   cbi.output_data["nr"] = nr
-  
+
   ret = call_julia_output_fcn(cbi,OUTPUTFCN_CALL_STEP,told,t,x,
                               cbi.eval_sol_fcn)
   if      ret == OUTPUTFCN_RET_STOP
@@ -169,19 +169,19 @@ function unsafe_odexSoloutCallback{FInt<:FortranInt,
   else
     throw(InternalErrorODE(string("Unkown ret=",ret," of output function")))
   end
-  
+
   return nothing
 end
 
 """
-        function unsafe_odexSoloutCallback_c{FInt,CI}(cbi::CI, 
+        function unsafe_odexSoloutCallback_c{FInt,CI}(cbi::CI,
                 fint_flag::FInt)
   """
 function unsafe_odexSoloutCallback_c{FInt,CI}(cbi::CI, fint_flag::FInt)
-  return cfunction(unsafe_odexSoloutCallback, Void, (Ptr{FInt}, 
-    Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, 
+  return cfunction(unsafe_odexSoloutCallback, Void, (Ptr{FInt},
+    Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
     Ptr{FInt}, Ptr{Float64}, Ptr{FInt},
-    Ptr{FInt}, Ptr{FInt}, Ptr{Float64}, 
+    Ptr{FInt}, Ptr{FInt}, Ptr{Float64},
     Ref{CI}, Ptr{FInt}))
 end
 
@@ -189,9 +189,9 @@ end
         function create_odex_eval_sol_fcn_closure{FInt<:FortranInt,
                 CI<:OdexInternalCallInfos}(
                 cbi::CI, d::FInt, method_contex::Ptr{Void})
-  
+
   generates a eval_sol_fcn for odex.
-  
+
   Why is a closure needed? We need a function `eval_sol_fcn`
   that calls `CONTEX_` (with `ccall`).
   But `CONTEX_` needs the informations for the current state. This
@@ -199,7 +199,7 @@ end
   `OdexInternalCallInfos`. `eval_sol_fcn` needs to get this informations.
   Here comes `create_odex_eval_sol_fcn_closure` into play: this function
   takes the call informations and generates a `eval_sol_fcn` with this data.
-  
+
   Why doesn't `unsafe_odexSoloutCallback` generate a closure (then
   the current state needs not to be saved in `OdexInternalCallInfos`)?
   Because then every call to `unsafe_odexSoloutCallback` would have
@@ -212,7 +212,7 @@ end
 function create_odex_eval_sol_fcn_closure{FInt<:FortranInt,
         CI<:OdexInternalCallInfos}(
         cbi::CI, d::FInt, method_contex::Ptr{Void})
-  
+
   function eval_sol_fcn_closure(s::Float64)
     (lio,l,lprefix)=(cbi.logio,cbi.loglevel,cbi.eval_lprefix)
     l_eval = l & LOG_EVALSOL>0
@@ -227,13 +227,13 @@ function create_odex_eval_sol_fcn_closure{FInt<:FortranInt,
       for k = 1:d
         cbi.cont_i[1] = k
         result[k] = ccall(method_contex,Float64,
-          (Ptr{FInt}, Ptr{Float64}, Ptr{Float64}, Ptr{FInt}, 
+          (Ptr{FInt}, Ptr{Float64}, Ptr{Float64}, Ptr{FInt},
            Ptr{FInt}, Ptr{FInt},),
           cbi.cont_i,cbi.cont_s, cbi.cont_con, cbi.cont_ncon,
           cbi.cont_icomp, cbi.cont_nd)
       end
     end
-    
+
     l_eval && println(lio,lprefix,"contex returned ",result)
     return result
   end
@@ -241,7 +241,7 @@ function create_odex_eval_sol_fcn_closure{FInt<:FortranInt,
 end
 
 """
-       function odex(rhs::Function, t0::Real, T::Real, 
+       function odex(rhs::Function, t0::Real, T::Real,
                      x0::Vector, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
 
@@ -250,10 +250,10 @@ end
         1: computation successful
         2: computation. successful, but interrupted by output function
        -1: error
-  
+
   main call for using Fortran-odex solver. In `opt` the following
   options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -332,10 +332,10 @@ end
       ╟─────────────────┼──────────────────────────────────────────┼─────────╢
       ║ OPT_RHO      &  │ safety factors for step control algorithm│    0.94 ║
       ║ OPT_RHO2        │ hnew=h*RHO*(RHO2*TOL/ERR)^(1/(k-1) )     │    0.65 ║
-      ╚═════════════════╧══════════════════════════════════════════╧═════════╝ 
+      ╚═════════════════╧══════════════════════════════════════════╧═════════╝
 
   """
-function odex(rhs::Function, t0::Real, T::Real,
+function odex(rhs, t0::Real, T::Real,
                 x0::Vector, opt::AbstractOptionsODE)
   return odex_impl(rhs,t0,T,x0,opt,OdexArguments{Int64}(Int64(0)))
 end
@@ -343,7 +343,7 @@ end
 """
   odex with 32bit integers, see odex.
   """
-function odex_i32(rhs::Function, t0::Real, T::Real,
+function odex_i32(rhs, t0::Real, T::Real,
                 x0::Vector, opt::AbstractOptionsODE)
 
   return odex_impl(rhs,t0,T,x0,opt,OdexArguments{Int32}(Int32(0)))
@@ -351,18 +351,18 @@ end
 
 
 """
-        function odex_impl{FInt<:FortranInt}(rhs::Function, 
-                t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+        function odex_impl{FInt<:FortranInt}(rhs::Function,
+                t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
                 args::OdexArguments{FInt})
-  
+
   implementation of odex for FInt.
   """
-function odex_impl{FInt<:FortranInt}(rhs::Function, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function odex_impl{FInt<:FortranInt}(rhs,
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::OdexArguments{FInt})
-  
+
   (lio,l,l_g,l_solver,lprefix) = solver_start("odex",rhs,t0,T,x0,opt)
-  
+
   (method_odex, method_contex) = getAllMethodPtrs(
      (FInt == Int64)? DL_ODEX : DL_ODEX_I32 )
 
@@ -372,7 +372,7 @@ function odex_impl{FInt<:FortranInt}(rhs::Function,
   args.ITOL = [ scalarFlag?0:1 ]
   args.IOUT = [ FInt( output_mode == OUTPUTFCN_NEVER? 0:
                      (output_mode == OUTPUTFCN_DENSE?2:1) )]
-  
+
   OPT = nothing; KM = FInt(0)
   try
     OPT=OPT_MAXEXCOLUMN; KM=convert(FInt,getOption(opt,OPT,9))
@@ -395,39 +395,39 @@ function odex_impl{FInt<:FortranInt}(rhs::Function,
     OPT=OPT_MAXSTEPS; args.IWORK[1] = convert(FInt,getOption(opt,OPT,10000))
     @assert 0 < args.IWORK[1]
     args.IWORK[2] = KM
-    
+
     OPT = OPT_STEPSIZESEQUENCE
     args.IWORK[3] = convert(FInt,getOption(opt,OPT,
       output_mode == OUTPUTFCN_DENSE?4:1))
     @assert 1 ≤ args.IWORK[3] ≤ 5
-    
+
     OPT=OPT_MAXSTABCHECKS; args.IWORK[4] = convert(FInt,getOption(opt,OPT,1))
-    
+
     OPT = OPT_MAXSTABCHECKLINE
     args.IWORK[5] = convert(FInt,getOption(opt,OPT,1))
-    
+
     OPT = OPT_DENSEOUTPUTWOEE
     supp_flag = convert(Bool,getOption(opt,OPT,false))
     args.IWORK[6] = FInt( supp_flag?1:0 )
     @assert !supp_flag || (supp_flag && output_mode == OUTPUTFCN_DENSE)
-    
+
     OPT = OPT_INTERPOLDEGREE
     args.IWORK[7] = convert(FInt,getOption(opt,OPT,4))
     @assert 1 ≤ args.IWORK[7] ≤ 6
-    
+
     args.IWORK[8] = nrdense
-    
+
     # fill WORK
     OPT=OPT_EPS; args.WORK[1]=convert(Float64,getOption(opt,OPT,2.3e-16))
     @assert 1e-35 < args.WORK[1] < 1.0
 
     OPT=OPT_MAXSS; args.WORK[2]=convert(Float64,getOption(opt,OPT,T-t0))
     @assert 0 ≠ args.WORK[2]
-    
+
     OPT=OPT_SSREDUCTION; args.WORK[3]=convert(Float64,getOption(opt,OPT,0.5))
     @assert args.WORK[1] < args.WORK[3] < 1.0
-    
-    OPT = OPT_SSSELECTPAR1; 
+
+    OPT = OPT_SSSELECTPAR1;
     args.WORK[4] = convert(Float64,getOption(opt,OPT,0.02))
     @assert 0 < args.WORK[4]
 
@@ -446,18 +446,18 @@ function odex_impl{FInt<:FortranInt}(rhs::Function,
     OPT = OPT_RHO2
     args.WORK[8] = convert(Float64,getOption(opt,OPT,0.65))
     @assert 0 < args.WORK[8]
-    
+
     OPT = OPT_RHO
     args.WORK[9] = convert(Float64,getOption(opt,OPT,0.94))
     @assert 0 < args.WORK[9]
-    
+
     # H
     OPT = OPT_INITIALSS
     args.H = [ convert(Float64,getOption(opt,OPT,1e-4)) ]
   catch e
     throw(ArgumentErrorODE("Option '$OPT': Not valid",:opt,e))
   end
-  
+
   args.RPAR = zeros(Float64,0)
   args.IDID = zeros(FInt,1)
   rhs_lprefix = "unsafe_HW1RHSCallback: "
@@ -505,7 +505,7 @@ function odex_impl{FInt<:FortranInt}(rhs::Function,
     args.N, args.FCN,
     args.t, args.x, args.tEnd,
     args.H,
-    args.RTOL, args.ATOL, args.ITOL, 
+    args.RTOL, args.ATOL, args.ITOL,
     args.SOLOUT, args.IOUT,
     args.WORK, args.LWORK,
     args.IWORK, args.LIWORK,
@@ -532,7 +532,7 @@ function odex_impl{FInt<:FortranInt}(rhs::Function,
   return ( args.t[1], args.x, args.IDID[1], stats)
 end
 
-"""  
+"""
   ## Compile ODEX
 
   The julia ODEInterface tries to compile and link the solvers
@@ -541,67 +541,67 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_odex_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile ODEX with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o odex.o odex.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
+
        gfortran -shared -fPIC -o odex.so odex.o
        gfortran -shared -fPIC -o odex.dylib odex.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile ODEX with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o odex.o odex.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
+
        gfortran -shared -o odex.dll odex.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile ODEX with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC  
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC
+                -fdefault-real-8 -fdefault-double-8
                 -o odex_i32.o   odex.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
        gfortran -shared -fPIC -o odex_i32.so odex_i32.o
        gfortran -shared -fPIC -o odex_i32.dylib odex_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile ODEX with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
+
        gfortran -c
-                -fdefault-real-8 -fdefault-double-8 
+                -fdefault-real-8 -fdefault-double-8
                 -o odex_i32.o   odex.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o odex_i32.dll odex_i32.o
-  
+
   """
 function help_odex_compile()
   return Docs.doc(help_odex_compile)
@@ -617,8 +617,8 @@ end
 push!(solverInfo,
   SolverInfo("odex",
     "GBS Extrapolation-Algorithm based on the explicit midpoint rule",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_MAXSTEPS, :OPT_EPS, :OPT_MAXS, :OPT_INITIALSS,
           :OPT_MAXEXCOLUMN, :OPT_STEPSIZESEQUENCE, :OPT_MAXSTABCHECKS,
           :OPT_MAXSTABCHECKLINE, :OPT_DENSEOUTPUTWOEE, :OPT_INTERPOLDEGREE,

--- a/src/Odex.jl
+++ b/src/Odex.jl
@@ -51,7 +51,7 @@ end
                output_fcn ( ... DONE ...)
   """
 type OdexInternalCallInfos{FInt<:FortranInt,
-       RHS_F<:Function, OUT_F<:Function } <: ODEinternalCallInfos
+       RHS_F, OUT_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   # RHS:

--- a/src/Radau.jl
+++ b/src/Radau.jl
@@ -82,8 +82,8 @@ end
            call_julia_output_fcn(  ... DONE ... )
                output_fcn ( ... DONE ...)
   """
-type RadauInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
-        OUT_F<:Function, JAC_F<:Function} <: ODEinternalCallInfos
+type RadauInternalCallInfos{FInt<:FortranInt, RHS_F,
+        OUT_F, JAC_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   # special structure

--- a/src/Rodas.jl
+++ b/src/Rodas.jl
@@ -29,7 +29,7 @@ end
 
 """
   Type encapsulating all required data for Rodas-Solver-Callbacks.
-  
+
   We have the typical calling stack:
 
        rodas
@@ -59,7 +59,7 @@ end
                output_fcn ( ... DONE ...)
   """
 type RodasInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
-        OUT_F<:Function, JAC_F<:Function, RHSDT_F<:Function} <: 
+        OUT_F<:Function, JAC_F<:Function, RHSDT_F<:Function} <:
                 ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
@@ -67,7 +67,7 @@ type RodasInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
   M1           :: FInt
   M2           :: FInt
   # RHS
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   # RHS time derivative
@@ -78,7 +78,7 @@ type RodasInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
   output_fcn   :: OUT_F                 # the output function to call
   output_data  :: Dict                  # extra_data for output_fcn
   out_lprefix  :: AbstractString        # saved log-prefix for solout
-  eval_sol_fcn :: Function              # eval_sol_fcn 
+  eval_sol_fcn :: Function              # eval_sol_fcn
   eval_lprefix :: AbstractString        # saved log-prefix for eval_sol
   tOld         :: Float64               # tOld and
   tNew         :: Float64               # tNew and
@@ -96,11 +96,11 @@ type RodasInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
 end
 
 """
-       type RodasArguments{FInt<:FortranInt} <: 
+       type RodasArguments{FInt<:FortranInt} <:
                 AbstractArgumentsODESolver{FInt}
-  
+
   Stores Arguments for Rodas solver.
-  
+
   FInt is the Integer type used for the fortran compilation.
   """
 type RodasArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
@@ -145,32 +145,32 @@ end
 """
         function unsafe_rodasSoloutCallback{FInt<:FortranInt,
                 CI<:RodasInternalCallInfos}(
-                nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-                x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-                n_::Ptr{FInt}, rpar_::Ptr{Float64}, cbi::CI, 
+                nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+                x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt},
+                n_::Ptr{FInt}, rpar_::Ptr{Float64}, cbi::CI,
                 irtrn_::Ptr{FInt})
-  
+
   This is the solout given as callback to Fortran-rodas.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
 
   This function saves the state informations of the solver in
   `RodasInternalCallInfos`, where they can be found by
   the `eval_sol_fcn`, see `create_rodas_eval_sol_fcn_closure`.
-  
+
   Then the user-supplied `output_fcn` is called (which in turn can use
   `eval_sol_fcn`, to evalutate the solution at intermediate points).
-  
+
   The return value of the `output_fcn` is propagated to `RODAS_`.
-  
+
   For the typical calling sequence, see `RodasInternalCallInfos`.
   """
 function unsafe_rodasSoloutCallback{FInt<:FortranInt,
         CI<:RodasInternalCallInfos}(
-        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-        x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-        n_::Ptr{FInt}, rpar_::Ptr{Float64}, cbi::CI, 
+        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+        x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt},
+        n_::Ptr{FInt}, rpar_::Ptr{Float64}, cbi::CI,
         irtrn_::Ptr{FInt})
 
   nr = unsafe_load(nr_); told = unsafe_load(told_); t = unsafe_load(t_)
@@ -211,8 +211,8 @@ end
   """
 function unsafe_rodasSoloutCallback_c{FInt,CI}(cbi::CI, fint_flag::FInt)
   return cfunction(unsafe_rodasSoloutCallback, Void, (Ptr{FInt},
-    Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, 
-    Ptr{Float64}, Ptr{FInt}, 
+    Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
+    Ptr{Float64}, Ptr{FInt},
     Ptr{FInt}, Ptr{Float64}, Ref{CI}, Ptr{FInt}))
 end
 
@@ -220,9 +220,9 @@ end
         function create_rodas_eval_sol_fcn_closure{FInt<:FortranInt,
                 CI<:RodasInternalCallInfos}(
                 cbi::CI, d::FInt, method_contro::Ptr{Void})
-  
+
   generates a eval_sol_fcn for rodas.
-  
+
   Why is a closure needed? We need a function `eval_sol_fcn`
   that calls `CONTRO_` (with `ccall`).
   But `CONTRO_` needs the informations for the current state. This
@@ -230,7 +230,7 @@ end
   `RodasInternalCallInfos`. `eval_sol_fcn` needs to get this informations.
   Here comes `create_rodas_eval_sol_fcn_closure` into play: this function
   takes the call informations and generates a `eval_sol_fcn` with this data.
-  
+
   Why doesn't `unsafe_rodasSoloutCallback` generate a closure (then
   the current state needs not to be saved in `RodasInternalCallInfos`)?
   Because then every call to `unsafe_rodasSoloutCallback` would have
@@ -243,7 +243,7 @@ end
 function create_rodas_eval_sol_fcn_closure{FInt<:FortranInt,
         CI<:RodasInternalCallInfos}(
         cbi::CI, d::FInt, method_contro::Ptr{Void})
-  
+
   function eval_sol_fcn_closure(s::Float64)
     (lio,l,lprefix)=(cbi.logio,cbi.loglevel,cbi.eval_lprefix)
     l_eval = l & LOG_EVALSOL>0
@@ -262,7 +262,7 @@ function create_rodas_eval_sol_fcn_closure{FInt<:FortranInt,
           cbi.cont_i,cbi.cont_s, cbi.cont_cont, cbi.cont_lrc)
       end
     end
-    
+
     l_eval && println(lio,lprefix,"contro returned ",result)
     return result
   end
@@ -274,7 +274,7 @@ end
         function rodas(rhs::Function, t0::Real, T::Real,
                        x0::Vector, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
-  
+
 
   `retcode` can have the following values:
 
@@ -287,9 +287,9 @@ end
 
   This solver support problems with special structure, see
   `help_specialstructure`.
-  
+
   In `opt` the following options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -388,7 +388,7 @@ end
       ║                 │ matrix (BandedMatrix).                   │         ║
       ╚═════════════════╧══════════════════════════════════════════╧═════════╝
   """
-function rodas(rhs::Function, t0::Real, T::Real,
+function rodas(rhs, t0::Real, T::Real,
                x0::Vector, opt::AbstractOptionsODE)
   return rodas_impl(rhs,t0,T,x0,opt,RodasArguments{Int64}(Int64(0)))
 end
@@ -396,12 +396,12 @@ end
 """
   rodas with 32bit integers, see rodas.
   """
-function rodas_i32(rhs::Function, t0::Real, T::Real,
+function rodas_i32(rhs, t0::Real, T::Real,
                    x0::Vector, opt::AbstractOptionsODE)
   return rodas_impl(rhs,t0,T,x0,opt,RodasArguments{Int32}(Int32(0)))
 end
 
-function rodas_impl{FInt<:FortranInt}(rhs::Function, 
+function rodas_impl{FInt<:FortranInt}(rhs,
         t0::Real, T::Real, x0::Vector,
         opt::AbstractOptionsODE, args::RodasArguments{FInt})
 
@@ -454,11 +454,11 @@ function rodas_impl{FInt<:FortranInt}(rhs::Function,
     OPT=OPT_METHODCHOICE; args.IWORK[2] = convert(FInt,getOption(opt,OPT,1))
     @assert 1 ≤ args.IWORK[2] ≤ 3
 
-    OPT = OPT_STEPSIZESTRATEGY; 
+    OPT = OPT_STEPSIZESTRATEGY;
     args.IWORK[3] = convert(FInt,getOption(opt,OPT,1))
     @assert args.IWORK[3] ∈ (1,2,)
 
-    args.IWORK[9] = M1 
+    args.IWORK[9] = M1
     args.IWORK[10] = M2
 
     OPT=OPT_EPS; args.WORK[1]=convert(Float64,getOption(opt,OPT,1e-16))
@@ -538,7 +538,7 @@ function rodas_impl{FInt<:FortranInt}(rhs::Function,
     args.N, args.FCN, args.IFCN,
     args.t, args.x, args.tEnd,
     args.H,
-    args.RTOL, args.ATOL, args.ITOL, 
+    args.RTOL, args.ATOL, args.ITOL,
     args.JAC, args.IJAC, args.MLJAC, args.MUJAC,
     args.DFX, args.IDFX,
     args.MAS, args.IMAS, args.MLMAS, args.MUMAS,
@@ -580,91 +580,91 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_rodas_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile RODAS with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o rodas.o rodas.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
-       gfortran -shared -fPIC -o rodas.so 
+       gfortran -shared -fPIC -o rodas.so
                 rodas.o dc_lapack.o lapack.o
        gfortran -shared -fPIC -o rodas.dylib
                 rodas.o dc_lapack.o lapack.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile RODAS with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o rodas.o rodas.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
-       gfortran -shared -o rodas.so 
+
+       gfortran -shared -o rodas.so
                 rodas.o dc_lapack.o lapack.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile RODAS with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o rodas_i32.o rodas.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
-       gfortran -shared -fPIC -o rodas_i32.so 
+
+       gfortran -shared -fPIC -o rodas_i32.so
                  rodas_i32.o dc_lapack_i32.o lapack_i32.o
        gfortran -shared -fPIC -o rodas_i32.dylib
                  rodas_i32.o dc_lapack_i32.o lapack_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile RODAS with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o rodas_i32.o rodas.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o rodas_i32.dll
                  rodas_i32.o dc_lapack_i32.o lapack_i32.o
-  
+
   """
 function help_rodas_compile()
   return Docs.doc(help_rodas_compile)
@@ -680,8 +680,8 @@ end
 push!(solverInfo,
   SolverInfo("rodas",
     "Rosenbrock method of order 4(3)",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_M1, :OPT_M2,
           :OPT_RHSAUTONOMOUS,
           :OPT_MASSMATRIX,

--- a/src/Rodas.jl
+++ b/src/Rodas.jl
@@ -58,8 +58,8 @@ end
            call_julia_output_fcn(  ... DONE ... )
                output_fcn ( ... DONE ...)
   """
-type RodasInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
-        OUT_F<:Function, JAC_F<:Function, RHSDT_F<:Function} <:
+type RodasInternalCallInfos{FInt<:FortranInt, RHS_F,
+        OUT_F, JAC_F, RHSDT_F} <:
                 ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level

--- a/src/Seulex.jl
+++ b/src/Seulex.jl
@@ -29,10 +29,10 @@ end
 
 """
   Type encapsulating all required data for Seulex-Solver-Callbacks.
-  
+
   We have the typical calling stack:
 
-       seulex       
+       seulex
            call_julia_output_fcn(  ... INIT ... )
                output_fcn ( ... INIT ...)
            ccall( SEULEX_  ... )
@@ -62,7 +62,7 @@ type SeulexInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
   M1           :: FInt
   M2           :: FInt
   # RHS:
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   # SOLOUT & output function
@@ -70,7 +70,7 @@ type SeulexInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
   output_fcn   :: OUT_F                 # the output function to call
   output_data  :: Dict                  # extra_data for output_fcn
   out_lprefix  :: AbstractString        # saved log-prefix for solout
-  eval_sol_fcn :: Function              # eval_sol_fcn 
+  eval_sol_fcn :: Function              # eval_sol_fcn
   eval_lprefix :: AbstractString        # saved log-prefix for eval_sol
   tOld         :: Float64               # tOld and
   tNew         :: Float64               # tNew and
@@ -90,11 +90,11 @@ type SeulexInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
 end
 
 """
-       type SeulexArguments{FInt<:FortranInt} <: 
+       type SeulexArguments{FInt<:FortranInt} <:
                 AbstractArgumentsODESolver{FInt}
-  
+
   Stores Arguments for Seulex solver.
-  
+
   FInt is the Integer type used for the fortran compilation.
   """
 type SeulexArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
@@ -136,32 +136,32 @@ end
 """
         function unsafe_seulexSoloutCallback{FInt<:FortranInt,
                 CI<:SeulexInternalCallInfos}(
-                nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-                x_::Ptr{Float64}, rc_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-                ic_::Ptr{FInt}, lic_::Ptr{FInt}, n_::Ptr{FInt}, 
+                nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+                x_::Ptr{Float64}, rc_::Ptr{Float64}, lrc_::Ptr{FInt},
+                ic_::Ptr{FInt}, lic_::Ptr{FInt}, n_::Ptr{FInt},
                 rpar_::Ptr{Float64}, cbi::CI, irtrn_::Ptr{FInt})
-  
+
   This is the solout given as callback to Fortran-seulex.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
 
   This function saves the state informations of the solver in
   `SeulexInternalCallInfos`, where they can be found by
   the `eval_sol_fcn`, see `create_seulex_eval_sol_fcn_closure`.
-  
+
   Then the user-supplied `output_fcn` is called (which in turn can use
   `eval_sol_fcn`, to evalutate the solution at intermediate points).
-  
+
   The return value of the `output_fcn` is propagated to `SEULEX_`.
-  
+
   For the typical calling sequence, see `SeulexInternalCallInfos`.
   """
 function unsafe_seulexSoloutCallback{FInt<:FortranInt,
         CI<:SeulexInternalCallInfos}(
-        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-        x_::Ptr{Float64}, rc_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-        ic_::Ptr{FInt}, lic_::Ptr{FInt}, n_::Ptr{FInt}, 
+        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+        x_::Ptr{Float64}, rc_::Ptr{Float64}, lrc_::Ptr{FInt},
+        ic_::Ptr{FInt}, lic_::Ptr{FInt}, n_::Ptr{FInt},
         rpar_::Ptr{Float64}, cbi::CI, irtrn_::Ptr{FInt})
 
   nr = unsafe_load(nr_); told = unsafe_load(told_); t = unsafe_load(t_)
@@ -174,9 +174,9 @@ function unsafe_seulexSoloutCallback{FInt<:FortranInt,
 
   l_sol && println(lio,lprefix,"called with nr=",nr," told=",told,
                                " t=",t," x=",x)
-  
+
   cbi.tOld = told; cbi.tNew = t; cbi.xNew = x;
-  cbi.cont_rc = rc_; cbi.cont_lrc = lrc_; 
+  cbi.cont_rc = rc_; cbi.cont_lrc = lrc_;
   cbi.cont_ic = ic_; cbi.cont_lic = lic_;
   cbi.output_data["nr"] = nr
 
@@ -193,7 +193,7 @@ function unsafe_seulexSoloutCallback{FInt<:FortranInt,
   else
     throw(InternalErrorODE(string("Unkown ret=",ret," of output function")))
   end
-  
+
   return nothing
 end
 
@@ -203,7 +203,7 @@ end
   """
 function unsafe_seulexSoloutCallback_c{FInt,CI}(cbi::CI, fint_flag::FInt)
   return cfunction(unsafe_seulexSoloutCallback, Void, (Ptr{FInt},
-    Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, 
+    Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
     Ptr{Float64}, Ptr{FInt}, Ptr{FInt}, Ptr{FInt},
     Ptr{FInt}, Ptr{Float64}, Ref{CI}, Ptr{FInt}))
 end
@@ -212,9 +212,9 @@ end
         function create_seulex_eval_sol_fcn_closure{FInt<:FortranInt,
                 CI<:SeulexInternalCallInfos}(
                 cbi::CI, d::FInt, method_contex::Ptr{Void})
-  
+
   generates a eval_sol_fcn for seulex.
-  
+
   Why is a closure needed? We need a function `eval_sol_fcn`
   that calls `CONTEX_` (with `ccall`).
   But `CONTEX_` needs the informations for the current state. This
@@ -222,7 +222,7 @@ end
   `SeulexInternalCallInfos`. `eval_sol_fcn` needs to get this informations.
   Here comes `create_seulex_eval_sol_fcn_closure` into play: this function
   takes the call informations and generates a `eval_sol_fcn` with this data.
-  
+
   Why doesn't `unsafe_seulexSoloutCallback` generate a closure (then
   the current state needs not to be saved in `SeulexInternalCallInfos`)?
   Because then every call to `unsafe_seulexSoloutCallback` would have
@@ -235,7 +235,7 @@ end
 function create_seulex_eval_sol_fcn_closure{FInt<:FortranInt,
         CI<:SeulexInternalCallInfos}(
         cbi::CI, d::FInt, method_contex::Ptr{Void})
-  
+
   function eval_sol_fcn_closure(s::Float64)
     (lio,l,lprefix)=(cbi.logio,cbi.loglevel,cbi.eval_lprefix)
     l_eval = l & LOG_EVALSOL>0
@@ -250,13 +250,13 @@ function create_seulex_eval_sol_fcn_closure{FInt<:FortranInt,
       for k = 1:d
         cbi.cont_i[1] = k
         result[k] = ccall(method_contex,Float64,
-          (Ptr{FInt}, Ptr{Float64}, Ptr{Float64}, Ptr{FInt}, 
+          (Ptr{FInt}, Ptr{Float64}, Ptr{Float64}, Ptr{FInt},
            Ptr{FInt}, Ptr{FInt},),
           cbi.cont_i,cbi.cont_s, cbi.cont_rc, cbi.cont_lrc,
           cbi.cont_ic, cbi.cont_lic)
       end
     end
-    
+
     l_eval && println(lio,lprefix,"contex returned ",result)
     return result
   end
@@ -267,7 +267,7 @@ end
        function seulex(rhs::Function, t0::Real, T::Real,
                        x0::Vector, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
-  
+
 
   `retcode` can have the following values:
 
@@ -277,12 +277,12 @@ end
 
 
   main call for using Fortran seulex solver.
-  
+
   This solver support problems with special structure, see
   `help_specialstructure`.
-  
+
   In `opt` the following options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -397,7 +397,7 @@ end
       ║                 │ WORKFORSOL: Forward- and Backward subst. │         ║
       ╚═════════════════╧══════════════════════════════════════════╧═════════╝
   """
-function seulex(rhs::Function, t0::Real, T::Real,
+function seulex(rhs, t0::Real, T::Real,
                 x0::Vector, opt::AbstractOptionsODE)
   return seulex_impl(rhs,t0,T,x0,opt,SeulexArguments{Int64}(Int64(0)))
 end
@@ -405,23 +405,23 @@ end
 """
   seulex with 32bit integers, see seulex.
   """
-function seulex_i32(rhs::Function, t0::Real, T::Real,
+function seulex_i32(rhs, t0::Real, T::Real,
                 x0::Vector, opt::AbstractOptionsODE)
   return seulex_impl(rhs,t0,T,x0,opt,SeulexArguments{Int32}(Int32(0)))
 end
 
-function seulex_impl{FInt<:FortranInt}(rhs::Function, 
+function seulex_impl{FInt<:FortranInt}(rhs, 
         t0::Real, T::Real, x0::Vector,
         opt::AbstractOptionsODE, args::SeulexArguments{FInt})
-  
+
   (lio,l,l_g,l_solver,lprefix) = solver_start("seulex",rhs,t0,T,x0,opt)
-  
+
   (method_seulex, method_contex) = getAllMethodPtrs(
      (FInt == Int64)? DL_SEULEX : DL_SEULEX_I32 )
 
   (d,nrdense,scalarFlag,rhs_mode,output_mode,output_fcn) =
     solver_extract_commonOpt(t0,T,x0,opt,args)
-  
+
   args.ITOL = [ scalarFlag?0:1 ]
   args.IOUT = [ FInt( output_mode == OUTPUTFCN_NEVER? 0:
                      (output_mode == OUTPUTFCN_DENSE?2:1) )]
@@ -442,30 +442,30 @@ function seulex_impl{FInt<:FortranInt}(rhs::Function,
   catch e
     throw(ArgumentErrorODE("Option '$OPT': Not valid",:opt,e))
   end
-  
+
   # WORK memory
   ljac = flag_jband? 1+args.MLJAC[1]+args.MUJAC[1]: NM1
   lmas = (!flag_implct)? 0 :
          (args.MLMAS[1] == NM1)? NM1 : 1+args.MLMAS[1]+args.MUMAS[1]
   le   = flag_jband? 1+2*args.MLJAC[1]+args.MUJAC[1] : NM1
   KM2  = 2+KM*ceil(FInt,(KM+3)/2)
-  
+
   args.LWORK = [ (M1==0)? d*(ljac+lmas+le+KM+8)+4*KM+20+KM2*nrdense :
                           d*(ljac+KM+8)+NM1*(lmas+le)+4*KM+20+KM2*nrdense ]
   args.WORK = zeros(Float64,args.LWORK[1])
-  
+
   # IWORK memory
   args.LIWORK = [ 2*d+KM+20+nrdense ]
   args.IWORK = zeros(FInt,args.LIWORK[1])
-  
+
   try
     OPT=OPT_RHSAUTONOMOUS;
     rhsautonomous = convert(Bool,getOption(opt,OPT,false))
     args.IFCN = [ rhsautonomous? 0:1 ]
 
-    OPT=OPT_TRANSJTOH; 
+    OPT=OPT_TRANSJTOH;
     transjtoh  = convert(Bool,getOption(opt,OPT,false))
-    @assert (!transjtoh) || 
+    @assert (!transjtoh) ||
             ( (!flag_jband) && (!flag_implct ))  string(
             "Does not work, if the jacobian is banded or if the system ",
             " has a mass matrix (≠Id).")
@@ -473,24 +473,24 @@ function seulex_impl{FInt<:FortranInt}(rhs::Function,
 
     OPT=OPT_MAXSTEPS; args.IWORK[2] = convert(FInt,getOption(opt,OPT,100000))
     @assert 0 < args.IWORK[2]
-    
+
     args.IWORK[3] = KM
 
     OPT = OPT_STEPSIZESEQUENCE
     args.IWORK[4] = convert(FInt,getOption(opt,OPT,2))
     @assert 1 ≤ args.IWORK[4] ≤ 4
-    
+
     OPT = OPT_LAMBDADENSE
     args.IWORK[5] = convert(FInt,getOption(opt,OPT,0))
     @assert args.IWORK[5] ∈ (0,1)
-    
+
     args.IWORK[6] = nrdense
 
     for k in 1:nrdense
       args.IWORK[20+k] = k
     end
 
-    args.IWORK[9] = M1 
+    args.IWORK[9] = M1
     args.IWORK[10] = M2
 
     OPT=OPT_EPS; args.WORK[1]=convert(Float64,getOption(opt,OPT,1e-16))
@@ -503,7 +503,7 @@ function seulex_impl{FInt<:FortranInt}(rhs::Function,
     args.WORK[3] = convert(Float64,getOption(opt,OPT,min(1e-4,args.RTOL[1])))
     @assert !(args.WORK[3]==0)
 
-    OPT = OPT_SSSELECTPAR1; 
+    OPT = OPT_SSSELECTPAR1;
     args.WORK[4] = convert(Float64,getOption(opt,OPT,0.1))
     @assert 0 < args.WORK[4]
 
@@ -522,11 +522,11 @@ function seulex_impl{FInt<:FortranInt}(rhs::Function,
     OPT = OPT_RHO2
     args.WORK[8] = convert(Float64,getOption(opt,OPT,0.8))
     @assert 0 < args.WORK[8]
-    
+
     OPT = OPT_RHO
     args.WORK[9] = convert(Float64,getOption(opt,OPT,0.93))
     @assert 0 < args.WORK[9]
-    
+
     OPT = OPT_WORKFORRHS
     args.WORK[10] = convert(Float64,getOption(opt,OPT,1.0))
     @assert 0 < args.WORK[10]
@@ -597,13 +597,13 @@ function seulex_impl{FInt<:FortranInt}(rhs::Function,
      Ptr{Void}, Ptr{FInt},                       # Soloutfunc, IOUT
      Ptr{Float64}, Ptr{FInt},                    # WORK, LWORK
      Ptr{FInt}, Ptr{FInt},                       # IWORK, LIWORK
-     Ptr{Float64}, Ref{SeulexInternalCallInfos}, # RPAR, IPAR 
+     Ptr{Float64}, Ref{SeulexInternalCallInfos}, # RPAR, IPAR
      Ptr{FInt},                                  # IDID
     ),
     args.N, args.FCN, args.IFCN,
     args.t, args.x, args.tEnd,
     args.H,
-    args.RTOL, args.ATOL, args.ITOL, 
+    args.RTOL, args.ATOL, args.ITOL,
     args.JAC, args.IJAC, args.MLJAC, args.MUJAC,
     args.MAS, args.IMAS, args.MLMAS, args.MUMAS,
     args.SOLOUT, args.IOUT,
@@ -635,8 +635,8 @@ function seulex_impl{FInt<:FortranInt}(rhs::Function,
   return ( args.t[1], args.x, args.IDID[1], stats)
 end
 
-"""  
-  ## Compile SEULEX 
+"""
+  ## Compile SEULEX
 
   The julia ODEInterface tries to compile and link the solvers
   automatically at the build-time of this module. The following
@@ -644,101 +644,101 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_seulex_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile SEULEX with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapackc.o lapackc.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o seulex.o seulex.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
-       gfortran -shared -fPIC -o seulex.so 
+       gfortran -shared -fPIC -o seulex.so
                 seulex.o dc_lapack.o lapack.o lapackc.o
        gfortran -shared -fPIC -o seulex.dylib
                 seulex.o dc_lapack.o lapack.o lapackc.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile SEULEX with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapackc.o lapackc.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o seulex.o seulex.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
-       gfortran -shared -o seulex.so 
+
+       gfortran -shared -o seulex.so
                 seulex.o dc_lapack.o lapack.o lapackc.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile SEULEX with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
-                -o lapackc_i32.o lapackc.f 
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
+                -o lapackc_i32.o lapackc.f
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o seulex_i32.o seulex.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
-       gfortran -shared -fPIC -o seulex_i32.so 
+
+       gfortran -shared -fPIC -o seulex_i32.so
                  seulex_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
        gfortran -shared -fPIC -o seulex_i32.dylib
                  seulex_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile SEULEX with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
-                -o lapackc_i32.o lapackc.f 
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
+                -o lapackc_i32.o lapackc.f
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o seulex_i32.o seulex.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o seulex_i32.dll
                  seulex_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
-  
+
   """
 function help_seulex_compile()
   return Docs.doc(help_seulex_compile)
@@ -754,8 +754,8 @@ end
 push!(solverInfo,
   SolverInfo("seulex",
     "Extrapolation method based on the linearly implicit Eueler method",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_M1, :OPT_M2,
           :OPT_RHSAUTONOMOUS,
           :OPT_MASSMATRIX,

--- a/src/Seulex.jl
+++ b/src/Seulex.jl
@@ -54,8 +54,8 @@ end
            call_julia_output_fcn(  ... DONE ... )
                output_fcn ( ... DONE ...)
   """
-type SeulexInternalCallInfos{FInt<:FortranInt, RHS_F<:Function,
-        OUT_F<:Function, JAC_F<:Function} <: ODEinternalCallInfos
+type SeulexInternalCallInfos{FInt<:FortranInt, RHS_F,
+        OUT_F, JAC_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   # special structure
@@ -410,7 +410,7 @@ function seulex_i32(rhs, t0::Real, T::Real,
   return seulex_impl(rhs,t0,T,x0,opt,SeulexArguments{Int32}(Int32(0)))
 end
 
-function seulex_impl{FInt<:FortranInt}(rhs, 
+function seulex_impl{FInt<:FortranInt}(rhs,
         t0::Real, T::Real, x0::Vector,
         opt::AbstractOptionsODE, args::SeulexArguments{FInt})
 


### PR DESCRIPTION
`Function` in Julia is an abstract type that not all functions actually subtype. Thus there are many functions in Julia, like callable types, which are restricted from using these ODE solvers because they don't `<:Function`. However, these work perfectly fine if the requirement for `::Function` is removed, meaning that it was unncessary. Since there's no performance difference when removing them, this makes the functions work on all Julia functions without hurting the performance.