### PR TITLE
Add Project.toml and update to Julia 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.dll
 *.swp
 *.zip
+/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,21 @@ os:
 julia:
   - 0.7
   - 1.0
+  - 1.1
   - nightly
-notifications:
-  email: false
-sudo: false
 addons:
   apt:
     packages:
       - gfortran
+matrix:
+  allow_failures:
+    - julia: nightly
+notifications:
+  email: false
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then  brew cask uninstall --force oclint || true ; brew install gcc; fi
-
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("ODEInterface"); Pkg.test("ODEInterface"; coverage=true)'
+after_success:
+  # push coverage results to Coveralls
+  - julia -e 'import Pkg; cd(Pkg.dir("ODEInterface")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  # push coverage results to Codecov
+  - julia -e 'import Pkg; cd(Pkg.dir("ODEInterface")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,20 @@
+name = "ODEInterface"
+uuid = "54ca160b-1b9f-5127-a996-1867f4bc2a2c"
+license = "MIT"
+authors = ["Christian Ludwig <ludwig@ma.tum.de>"]
+version = "0.4.5"
+
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[compat]
+julia = ">= 0.7"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,0 @@
-julia 0.7-DEV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,22 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
 
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
 matrix:
   allow_failures:
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+    - julia_version: nightly
 
 branches:
   only:
     - master
-    - julia_v0.4-v0.6
     - /release-.*/
 
 notifications:
@@ -21,19 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"ODEInterface\"); Pkg.build(\"ODEInterface\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"ODEInterface\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/ODEInterface.jl
+++ b/src/ODEInterface.jl
@@ -1,5 +1,3 @@
-__precompile__(true)
-
 """
   # ODEInterface
   
@@ -94,11 +92,8 @@ __precompile__(true)
   """
 module ODEInterface
 
+using LinearAlgebra
 using Unicode
-try
-  using LinearAlgebra
-catch
-end
 
 include("./Error.jl")
 include("./Options.jl")


### PR DESCRIPTION
This PR removes REQUIRE, adds Project.toml, and updates the package and the CI to Julia 1.1. I enabled tests for different Julia versions but, of course, this could be adjusted if, e.g., you want to drop tests for Julia 0.7.