### PR TITLE
Find module path more reliably

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ODEInterface"
 uuid = "54ca160b-1b9f-5127-a996-1867f4bc2a2c"
 license = "MIT"
 authors = ["Christian Ludwig <ludwig@ma.tum.de>"]
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Banded.jl
+++ b/src/Banded.jl
@@ -20,34 +20,34 @@ end
 
 """
   Type for storing and changing a banded matrix.
-  
+
   ## Introduction (connections to proposal #8240)
-  
+
   This is a simple type for storing banded matrices in the band storage
   format used by LAPACK:
-  
+
        http://www.netlib.org/lapack/lug/node124.html
-  
+
   The emphasis here is on *storing* and *changing* the matrix elements,
   because this is needed in the ODE-context.
-  
+
   This is *not* an attempt to fully implement efficient arithmetic
   for banded matrices. This problem is discussed in proposal #8240:
-  
+
        https://github.com/JuliaLang/julia/issues/8240
-  
+
   ## What are banded matrices?
-  
+
   Take a look at the diaognals of a matrix, e.g.
-  
+
        ⎛1 4 2    ⎞
        ⎜5 2 3 1  ⎟
        ⎜  4 3 0 0⎟
        ⎜    3 4 8⎟
        ⎝      2 5⎠
-  
+
   Then we give the following names to the diagonals:
-  
+
                  0  1 2 3  upper diagonals
                    ↘ ↘ ↘ ↘
                  1  1╲4╲2╲0╲0
@@ -59,35 +59,35 @@ end
                     0╲0╲3╲4╲8
                     ╲ ╲ ╲ ╲ ╲
                     0╲0╲0╲2╲5
-  
+
   The 0 diagonal is the main diagonal. The 1st diagonal above this main
-  diagonal is called the 1st upper diagonal, etc. 
+  diagonal is called the 1st upper diagonal, etc.
   The 1st digonal below the main diagonal is called the 1st lower diagonal.
-  
+
   A matrix has lower bandwidth l, if all diagonals below the l lower diagonal
   have only zeros. In the above example the matrix has lower bandwidth l=1
   because the 2nd, 3rd and 4th lower diagonals are all zero.
-  
+
   A matrix has upper bandwidth u, if all diagonals above the u upper diagonal
   have only zeros. In the above example the matrix has upper bandwidth u=2.
-  
-  A m×n matrix (with m,n ≥ 2) is called banded, if it has a 
+
+  A m×n matrix (with m,n ≥ 2) is called banded, if it has a
   lower bandwidth l<m-2 and/or a upper bandwidth u<n-2.
 
   ## What is this type for?
-  
+
   This types stores banded matrices. There are functions for banded matrices
   to make it easy to query and change the elements of a banded matrix.
-  
+
   ## Why is this type immutable? Can the entries be changed?
-  
+
   A banded matrix is immutable, i.e. the structure (the upper and lower
   bandwidths cannot be changed). The entries of a banded matrix are *not*
-  immutable. 
-  
+  immutable.
+
   For an explanation of the storage format, see the help of
   `BandedMatrix_storage`.
-  
+
   There is a constructur, where you can give the entries array for
   the non-zero elements (diagonals) as input argument.
   """
@@ -95,10 +95,10 @@ struct BandedMatrix{T}    <: AbstractMatrix{T}
   m            :: Integer               # number of rows of banded matrix
   n            :: Integer               # number of colums
                                         #    currently: n == size(entries,2)
-  l            :: Integer               # lower bandwidth 
+  l            :: Integer               # lower bandwidth
   u            :: Integer               # upper bandwidth
   entries      :: AbstractArray{T}      # array with entries
-  
+
   function BandedMatrix{T}(m::Integer,n::Integer,l::Integer,u::Integer,
                                 entries::AbstractArray{T}) where T
     m ≥ 1 || throw(ArgumentErrorODE("requirement m≥1", :m))
@@ -120,36 +120,36 @@ end
 
 """
   ## How are the non-zero entries stored (in this type)?
-  
+
   If M is a m×n matrix with upper bandwidth u and lower bandwith l, then
   the non-zero entries are saved in a (1+l+u)×n matrix N with
-  
+
        N(i-j+u+1,j) = M(i,j) with
-  
+
         max(1,j-u) ≤ i ≤ min(m,l+j)  ⎫   ⎧ -u ≤ i-j ≤ l
                                      ⎬ ⇔ ⎨  1 ≤ i   ≤ m
         max(1,i-l) ≤ j ≤ max(n,u+i)  ⎭   ⎩  1 ≤ j   ≤ n
-  
+
   This is the storage format described in the follwing URL.
-  
+
        http://www.netlib.org/lapack/lug/node124.html
-  
+
   This is not the place to discuss, if a (1+l+u)×min(m,n) matrix is a better
   format for storing the diagonals.
 
-       M(i,j) = N(i-j+u+1,j)  
+       M(i,j) = N(i-j+u+1,j)
        N(r,s) = M(r+s-1-u,s)
-  
+
   There can be entries in the matrix N that do *not* correspond to entries
   in M. In this type they are also zero. Great care is taken not to change
   this zeros in order not to violate the `==` and `hash` "contract": Because
   this uncorresponding entries cannot be seen in M, they should have no
   effect on the hash and on the `==` relation.
-  
+
   Keep in mind: There are two different ways of numbering the diagonals.
   The (internal) form ranging from 1 to 1+u+l and the user-friendly form
   ranging von -l ≤ d ≤ u, see `BandedMatrix`.
-  
+
   For the example
 
        ⎛1 4 2    ⎞
@@ -193,13 +193,13 @@ function hash(bm::BandedMatrix, h::UInt)
 end
 
 function ==(bm1::BandedMatrix, bm2::BandedMatrix)
-  return (bm1.m==bm2.m) && (bm1.n==bm2.n) && 
+  return (bm1.m==bm2.m) && (bm1.n==bm2.n) &&
          (bm1.l==bm2.l) && (bm1.u==bm2.u) && (bm1.entries==bm2.entries)
 end
 
 function isequal(bm1::BandedMatrix, bm2::BandedMatrix)
-  return (bm1.m==bm2.m) && (bm1.n==bm2.n) && 
-         (bm1.l==bm2.l) && (bm1.u==bm2.u) && 
+  return (bm1.m==bm2.m) && (bm1.n==bm2.n) &&
+         (bm1.l==bm2.l) && (bm1.u==bm2.u) &&
          isequal(bm1.entries,bm2.entries)
 end
 
@@ -218,7 +218,7 @@ end
   The columns in `bm.entries` for diagonal 1 ≤ d ≤ 1+l+u.
   """
 function rangeofdiag(bm::BandedMatrix,d::Integer)
-  return  max(1,2+bm.u-d):min(bm.n,bm.m+bm.u+1-d) 
+  return  max(1,2+bm.u-d):min(bm.n,bm.m+bm.u+1-d)
 end
 
 """
@@ -230,10 +230,10 @@ end
 
 """
   tests if `(i,j)` is in the diagonal bands.
-  
+
   Caution: This methods does *not* test, if `i` and `j` are
   inside the matrix bounds. Only the diagonal bounds are checked.
-  
+
   This method should only be used, if the matrix bounds/dimensions
   have been checked before.
   """
@@ -249,7 +249,7 @@ function fill!(bm::BandedMatrix,x)
 end
 
 """
-  sets the diagonal with number `d` (0 is the main diagonal,see 
+  sets the diagonal with number `d` (0 is the main diagonal,see
   `BandedMatrix`) to the given values.
   """
 function setdiagonal!(bm::BandedMatrix,d::Integer,value)
@@ -287,11 +287,11 @@ end
 
 """
   sets all diagonals at once copy the diagonals from an other BandedMatrix.
-  The other Bandedmatrix must have the same size and same upper and 
+  The other Bandedmatrix must have the same size and same upper and
   lower bandwidth.
   """
 function setdiagonals!(bm::BandedMatrix{T},other::BandedMatrix{T}) where T
-  if bm.m ≠ other.m || bm.n ≠ other.n || 
+  if bm.m ≠ other.m || bm.n ≠ other.n ||
      bm.u ≠ other.u || bm.l ≠ other.l
     throw(ArgumentErrorODE(string("bm has size ",size(bm),
       " and l=",bm.l,", u=",bm.u,"; but other has size ",size(other),
@@ -310,14 +310,14 @@ function setindex!(bm::BandedMatrix,value,i::Integer,j::Integer)
 end
 
 function setindex!(bm::BandedMatrix,value,ra::UnitRange,j::Integer)
-  (isvalidinband(bm,ra.start,j) && isvalidinband(bm,ra.stop,j)) || 
-                                   throw(BoundsError(bm,(ra,j))) 
+  (isvalidinband(bm,ra.start,j) && isvalidinband(bm,ra.stop,j)) ||
+                                   throw(BoundsError(bm,(ra,j)))
   bm.entries[(ra.start+bm.u+1-j):(ra.stop+bm.u+1-j),j] = value
 end
 
 function setindex!(bm::BandedMatrix,value,i::Integer,ra::UnitRange)
   (isvalidinband(bm,i,ra.start) && isvalidinband(bm,i,ra.stop)) ||
-                                   throw(BoundsError(bm,(i,ra))) 
+                                   throw(BoundsError(bm,(i,ra)))
   ni = i+bm.u+1-ra.start; nj = ra.start
   for k = 1:length(ra)
     bm.entries[ni,nj] = isa(value,Number) ? value : value[k]
@@ -326,11 +326,11 @@ function setindex!(bm::BandedMatrix,value,i::Integer,ra::UnitRange)
 end
 
 function setindex!(bm::BandedMatrix,value,zra::UnitRange,sra::UnitRange)
-  (isvalidinband(bm,zra.start,sra.start) && 
-   isvalidinband(bm,zra.stop,sra.stop)) || throw(BoundsError(bm,(zra,sra))) 
+  (isvalidinband(bm,zra.start,sra.start) &&
+   isvalidinband(bm,zra.stop,sra.stop)) || throw(BoundsError(bm,(zra,sra)))
   s = 1
   for nj in sra
-    ni = zra.start+bm.u+1-nj; 
+    ni = zra.start+bm.u+1-nj;
     for z = 1:length(zra)
       bm.entries[ni,nj] = isa(value,Number) ? value : value[z,s]
       ni += 1;
@@ -387,7 +387,7 @@ function createBandedMatrix(A::AbstractMatrix{T}) where T
     d+=1
   end
   l = -d
-  
+
   bm = BandedMatrix(m,n,l,u,zero(T))
   for j in 1:bm.n
     for i in  max(1,j-bm.u):min(bm.l+j,bm.m)
@@ -401,7 +401,7 @@ end
 
 """
   Convert banded matrix `bm` to full matrix. Save full matrix values in `f`.
-  
+
   `f` must have the right size.
   """
 function fullToArray(bm::BandedMatrix{T},f::AbstractArray{T}) where T

--- a/src/Base.jl
+++ b/src/Base.jl
@@ -49,7 +49,7 @@ const LOG_JAC        = UInt64(1)<<7
 """Bitmask: log calls to boundary condition function."""
 const LOG_BC         = UInt64(1)<<8
 
-"""Bitmask: during boundary value problems: 
+"""Bitmask: during boundary value problems:
   log calls to initial value solver."""
 const LOG_BVPIVPSOL  = UInt64(1)<<9
 
@@ -72,7 +72,7 @@ macro import_LOG()
   :(
     using ODEInterface: LOG_NOTHING, LOG_GENERAL, LOG_RHS,
                         LOG_SOLVERARGS, LOG_SOLOUT, LOG_OUTPUTFCN,
-                        LOG_EVALSOL, LOG_MASS, LOG_JAC, LOG_BC, 
+                        LOG_EVALSOL, LOG_MASS, LOG_JAC, LOG_BC,
                         LOG_BVPIVPSOL, LOG_RHSDT, LOG_JACBC,
                         LOG_GUESS,
                         LOG_ALL
@@ -82,12 +82,12 @@ end
 """
        function getVectorCheckLength(vec,T::DataType,d::Integer,copy=true)
                          -> Vector{T}
-  
+
   try to convert to `Vector{T}` and checks given length.
   If the `docopy` argument is `true` then the return value will
   always be a different object than `vec`: If `convert` didn't need to
   create a copy then this is done by this function.
-  
+
   throws ArgumentErrorODE this is not possible.
   """
 function getVectorCheckLength(vec,T::DataType,d::Integer,docopy=true)
@@ -110,12 +110,12 @@ end
 """
        function getMatrixCheckSize(mat,T::DataType,
                     m::Integer,n::Integer,docopy=true) -> Matrix{T}
-  
+
   try to convert to `Matrix{T}' and checks the size.
   if the `docopy` argument is `true` then the return value will
   always be a different object than `mat`: If `convert` didn't need
   to create a copy then this is done by this function.
-  
+
   throws ArgumentErrorODE this is not possible.
   """
 function getMatrixCheckSize(mat,T::DataType,m::Integer,n::Integer,docopy=true)

--- a/src/Bvpm2.jl
+++ b/src/Bvpm2.jl
@@ -63,7 +63,7 @@ bvpm2_global_cbi = nothing
   │ │ │ │  the guess_pthrough info is available.]
   │ │ │ │ [convert Fortran Arrays to C-Pointer-Array]
   │ │ │ │ call guess_fcn_ptr/unsafe_bvpm2_guess_cb_c(x_point, ...,
-  │ │ │ │ │                  ───────────────────────   guess_vector 
+  │ │ │ │ │                  ───────────────────────   guess_vector
   │ │ │ │ │                                            guess_pthrough)
   │ │ │ │ │   [ use guess_pthrough to recover cbi ]
   │ │ │ │ │   call cbi.guess_fcn(x, guess_vector)
@@ -71,7 +71,7 @@ bvpm2_global_cbi = nothing
   └ └ └ └ └   └
 
   Legend:
-     ─────────  julia code 
+     ─────────  julia code
      ━━━━━━━━━  Fortran2003 code in BVP_M_Proxy with ISO_C_BINDING
      ═════════  Fortran2003 code in BVP_M-2 (without ISO_C_BINDING)
   ```
@@ -115,8 +115,8 @@ end
 """
   # Bvpm2 object for solving boundary value problems
 
-  This is the Julia part of the BVP_M-2 (Fortran-)solution object. 
-  For (nearly) all the operations the corresponding Fortran-Proxy 
+  This is the Julia part of the BVP_M-2 (Fortran-)solution object.
+  For (nearly) all the operations the corresponding Fortran-Proxy
   methods are called (call `help_bvpm2_proxy()` to get internal details).
 
   ## Boundary value problem (BVP)
@@ -131,9 +131,9 @@ end
         ga(y(a), p) = 0,     gb(y(b), p) = 0                     [BCs]
 
   * y(x) ∈ ℝᵈ and `d` is also called `no_odes` (the number of ordinary
-    differential equations). 
-  * S ∈ ℝᵈˣᵈ is an optional constant matrix (also 
-    called the singularity term) because the whole term S⋅y/(x-a) has a 
+    differential equations).
+  * S ∈ ℝᵈˣᵈ is an optional constant matrix (also
+    called the singularity term) because the whole term S⋅y/(x-a) has a
     singularity at x=a. If S is not given, then the ODEs are reduced to
     y'(x) = f(x, y, p).
   * p ∈ ℝᵐ (with 0≤m) are unknown parameters of the problem. `m` is also
@@ -143,25 +143,25 @@ end
     also called `no_left_bc` (the number of the BCs at x=a).
   * ga(yb, p) ∈ ℝⁿ describes the right boundary conditions. It is
 
-          n = d + m - l 
+          n = d + m - l
           n = no_odes + no_par - no_left_bc
 
   ## Initial guess and solutions
 
-  A Bvpm2 object can be used to represent either an initial guess (for a 
-  BVP like above) or a solution. It is possible to use a solution of a 
+  A Bvpm2 object can be used to represent either an initial guess (for a
+  BVP like above) or a solution. It is possible to use a solution of a
   (different) BVP as initial guess to another BVP.
 
   Such a Bvpm2 object can be in one of the following states:
-  
-  * `state==0`: object created (and connected to Fortran-object), but 
+
+  * `state==0`: object created (and connected to Fortran-object), but
     not initialized, i.e. it does neither represent a guess nor an solution.
   * `state==1`: object created, and initialized with an (initial) guess, i.e.
     the object represents a guess.
   * `state==2`: object created and a solution was calculated successfully and
     saved in the object, i.e. the object represents a solution.
   * `state==-1`: object is not connected to a Fortran-Proxy. Either
-    `bvpm2_destroy` was called or at creation time, the connection to the 
+    `bvpm2_destroy` was called or at creation time, the connection to the
      Fortran-Proxy couldn't be established, i.e. the object is unusable and
      all associated memory was deallocated.
 
@@ -200,10 +200,10 @@ end
   ║ bvpm2_destroy     │ deallocate all (Fortran-) │ -1, 0, 1,  │     -1     ║
   ║                   │ resources for this object.│   or 2     │            ║
   ║                   │                           │            │            ║
-  ╚═══════════════════╧═══════════════════════════╧════════════╧════════════╝ 
+  ╚═══════════════════╧═══════════════════════════╧════════════╧════════════╝
   ```
 
-  There are functions that take an Bvpm2-object `obj_in` as input, 
+  There are functions that take an Bvpm2-object `obj_in` as input,
   perhaps change `obj_in` and create an additonal `obj_out`.
 
   The following table shows possible actions, the change of the state
@@ -229,7 +229,7 @@ end
   ║                   │ Call bvpm2_copy before, if│            │            ║
   ║                   │ you need the solution     │            │            ║
   ║                   │ later on.                 │            │            ║
-  ╚═══════════════════╧═══════════════════════════╧════════════╧════════════╝ 
+  ╚═══════════════════╧═══════════════════════════╧════════════╧════════════╝
   ```
 
   """
@@ -269,7 +269,7 @@ end
 
 """
        function bvpm2_create_handle(obj::Bvpm2)
-  
+
   create Fortran Proxy.
   """
 function bvpm2_create_handle(obj::Bvpm2)
@@ -303,7 +303,7 @@ function get_proxy_methods(obj::Bvpm2)
    obj.method_init_guess1,
    obj.method_init_guess2,
    obj.method_init_guess3,
-   obj.method_solve, 
+   obj.method_solve,
    obj.method_eval_s,
    obj.method_eval_v,
    obj.method_get_params,
@@ -460,7 +460,7 @@ end
 function bvpm2_get_params(obj::Bvpm2)
   details = bvpm2_check_state(obj, (1, 2))
   p = Vector{Float64}(undef, details["no_par"])
-  if length(p) > 0 
+  if length(p) > 0
     error = ccall(obj.method_get_params, Int64,
       (Ptr{Cvoid}, Int64, Ref{Float64},),   # handle, p_len, p
       obj.handle, length(p), p)
@@ -478,12 +478,12 @@ function getSolutionGrid(sol::Bvpm2)
 end
 
 """
-       function bvpm2_init_tests(obj::Bvpm2, no_odes, no_left_bc, 
+       function bvpm2_init_tests(obj::Bvpm2, no_odes, no_left_bc,
            x_grid::Vector, parameters::Vector, max_num_subintervals)
 
   init tests for common parameters.
   """
-function bvpm2_init_tests(obj::Bvpm2, no_odes, no_left_bc, 
+function bvpm2_init_tests(obj::Bvpm2, no_odes, no_left_bc,
     x_grid::Vector, parameters::Vector, max_num_subintervals)
 
   details = bvpm2_check_state(obj, (0,))
@@ -500,14 +500,14 @@ function bvpm2_init_tests(obj::Bvpm2, no_odes, no_left_bc,
     no_left_bc = convert(Int64, no_left_bc)
     @assert no_left_bc ≥ 0
   catch e
-    throw(ArgumentErrorODE("no_left_bc must be non-negative integer", 
+    throw(ArgumentErrorODE("no_left_bc must be non-negative integer",
       :no_left_bc, e))
   end
 
   len_x_grid = length(x_grid)
   if len_x_grid <= 2
     throw(ArgumentErrorODE(string(
-      "x_grid must have length > 2. You must specify an initial grid."), 
+      "x_grid must have length > 2. You must specify an initial grid."),
       :x_grid))
   end
   try
@@ -517,7 +517,7 @@ function bvpm2_init_tests(obj::Bvpm2, no_odes, no_left_bc,
     throw(ArgumentErrorODE("cannot convert x_grid to Float64 vector",
       :x_grid, e))
   end
-  
+
   try
     parameters = getVectorCheckLength(parameters, Float64,
       length(parameters))
@@ -525,13 +525,13 @@ function bvpm2_init_tests(obj::Bvpm2, no_odes, no_left_bc,
     throw(ArgumentErrorODE("cannot convert parameters to a Float64 vector",
       :parameters, e))
   end
-  
+
   try
     max_num_subintervals = convert(Int64, max_num_subintervals)
     @assert max_num_subintervals > 0
     @assert max_num_subintervals ≥ length(x_grid)-1
   catch e
-    throw(ArgumentErrorODE("max_num_subintervals must be positive integer", 
+    throw(ArgumentErrorODE("max_num_subintervals must be positive integer",
       :max_num_subintervals, e))
   end
 
@@ -540,27 +540,27 @@ end
 
 """
        function bvpm2_init(obj::Bvpm2,
-         no_odes, no_left_bc, x_grid::Vector, constant_guess::Vector, 
+         no_odes, no_left_bc, x_grid::Vector, constant_guess::Vector,
          parameters::Vector=[], max_num_subintervals=3000)
 
   initialize Bvpm2 object with a constant intial guess.
   """
 function bvpm2_init(obj::Bvpm2,
-  no_odes, no_left_bc, x_grid::Vector, constant_guess::Vector, 
+  no_odes, no_left_bc, x_grid::Vector, constant_guess::Vector,
   parameters::Vector=[], max_num_subintervals=3000)
-  
+
   details, no_odes, no_left_bc, x_grid, parameters, max_num_subintervals =
-    bvpm2_init_tests(obj, no_odes, no_left_bc, x_grid, parameters, 
+    bvpm2_init_tests(obj, no_odes, no_left_bc, x_grid, parameters,
                      max_num_subintervals)
 
   try
-    constant_guess = getVectorCheckLength(constant_guess, 
+    constant_guess = getVectorCheckLength(constant_guess,
       Float64, no_odes)
   catch e
     throw(ArgumentErrorODE(string("cannot convert constant_guess to a ",
       "Float64 vector of length ",no_odes), :constant_guess, e))
   end
-  
+
   ccall(obj.method_init_guess1, Cvoid,
     (Ptr{Cvoid},                           # handle
      Int64, Int64,                         # no_odes, no_left_bc
@@ -575,24 +575,24 @@ function bvpm2_init(obj::Bvpm2,
     length(constant_guess), constant_guess,
     length(parameters), parameters,
     max_num_subintervals)
-  
+
   return obj
 end
 
 """
        function bvpm2_init(obj::Bvpm2,
-         no_odes, no_left_bc, x_grid::Vector, guess::Matrix, 
+         no_odes, no_left_bc, x_grid::Vector, guess::Matrix,
          parameters::Vector=[], max_num_subintervals=3000)
 
   initialize Bvpm2 object with a guess for every state at
   every node in x_grid.
   """
 function bvpm2_init(obj::Bvpm2,
-  no_odes, no_left_bc, x_grid::Vector, guess::Matrix, 
+  no_odes, no_left_bc, x_grid::Vector, guess::Matrix,
   parameters::Vector=[], max_num_subintervals=3000)
-  
+
   details, no_odes, no_left_bc, x_grid, parameters, max_num_subintervals =
-    bvpm2_init_tests(obj, no_odes, no_left_bc, x_grid, parameters, 
+    bvpm2_init_tests(obj, no_odes, no_left_bc, x_grid, parameters,
                      max_num_subintervals)
   try
     m,n = size(guess)
@@ -645,10 +645,10 @@ end
 """
   This is the guess function given as callback to bvpm2.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
-function unsafe_bvpm2_guess_cb(x::Float64, y_len::Int64, y_::Ptr{Float64}, 
+function unsafe_bvpm2_guess_cb(x::Float64, y_len::Int64, y_::Ptr{Float64},
      cbi::CI) where CI<:Bvpm2_guess_cbi
 
   @assert y_len == cbi.no_odes
@@ -663,8 +663,8 @@ function unsafe_bvpm2_guess_cb_c(cbi::CI) where CI
 end
 
 """
-       function bvpm2_init(obj, no_odes, no_left_bc, x_grid, 
-                           guess<:Function, parameters, 
+       function bvpm2_init(obj, no_odes, no_left_bc, x_grid,
+                           guess<:Function, parameters,
                            max_num_subintervals=3000)
 
   The guess function must have the form
@@ -678,11 +678,11 @@ end
   to get the guesses for the state at different `x` values.
   """
 function bvpm2_init(obj::Bvpm2,
-  no_odes, no_left_bc, x_grid::Vector, guess::GUESS_FCN, 
+  no_odes, no_left_bc, x_grid::Vector, guess::GUESS_FCN,
   parameters::Vector=[], max_num_subintervals=3000) where GUESS_FCN<:Function
 
   details, no_odes, no_left_bc, x_grid, parameters, max_num_subintervals =
-    bvpm2_init_tests(obj, no_odes, no_left_bc, x_grid, parameters, 
+    bvpm2_init_tests(obj, no_odes, no_left_bc, x_grid, parameters,
                      max_num_subintervals)
 
   # Create callback-info
@@ -730,11 +730,11 @@ end
   This is the right-hand side given as callback to bvpm2 in the
   case where the problem has no unkown parameters.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_bvpm2_rhs_cb(
-    x::Float64, y_len::Int64, y_::Ptr{Float64}, 
+    x::Float64, y_len::Int64, y_::Ptr{Float64},
     f_len::Int64, f_::Ptr{Float64}, cbi::CI) where CI<:Bvpm2_solve_cbi
 
   @assert y_len == f_len == cbi.no_odes
@@ -754,11 +754,11 @@ end
   This is the right-hand side given as callback to bvpm2 in the
   case where the problem has unknown parameters.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_bvpm2_rhspar_cb(
-    x::Float64, y_len::Int64, y_::Ptr{Float64}, 
+    x::Float64, y_len::Int64, y_::Ptr{Float64},
     p_len::Int64, p_::Ptr{Float64},
     f_len::Int64, f_::Ptr{Float64}, cbi::CI) where CI<:Bvpm2_solve_cbi
 
@@ -801,17 +801,17 @@ end
   This is the derivative of the right-hand side given as callback to
   bvpm2 in the case where the problem has no unknown parameters.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_bvpm2_Drhs_cb(
   x::Float64, y_len::Int64, y_::Ptr{Float64},
-  dfdy_dim1::Int64, dfdy_dim2::Int64, dfdy_::Ptr{Float64}, 
+  dfdy_dim1::Int64, dfdy_dim2::Int64, dfdy_::Ptr{Float64},
   cbi::CI) where CI<:Bvpm2_solve_cbi
 
   @assert y_len == cbi.no_odes
   @assert dfdy_dim1 == dfdy_dim2 == cbi.no_odes
-  
+
   y = unsafe_wrap(Array, y_, (y_len,), own=false)
   dfdy = unsafe_wrap(Array, dfdy_, (dfdy_dim1, dfdy_dim2,), own=false)
   bvpm2_Drhs(x, y, dfdy, cbi)
@@ -827,20 +827,20 @@ end
   This is the derivative of the right-hand side given as callback to
   bvpm2 in the case where the problem has unknown parameters.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_bvpm2_Drhspar_cb(
   x::Float64, y_len::Int64, y_::Ptr{Float64},
   p_len::Int64, p_::Ptr{Float64},
-  dfdy_dim1::Int64, dfdy_dim2::Int64, dfdy_::Ptr{Float64}, 
+  dfdy_dim1::Int64, dfdy_dim2::Int64, dfdy_::Ptr{Float64},
   dfdp_dim1::Int64, dfdp_dim2::Int64, dfdp_::Ptr{Float64},
   cbi::CI) where CI<:Bvpm2_solve_cbi
 
   @assert y_len == cbi.no_odes
   @assert dfdy_dim1 == dfdy_dim2 == cbi.no_odes
   @assert dfdp_dim1 == cbi.no_odes && dfdp_dim2 == cbi.no_par
-  
+
   y = unsafe_wrap(Array, y_, (y_len,), own=false)
   p = unsafe_wrap(Array, p_, (p_len,), own=false)
   dfdy = unsafe_wrap(Array, dfdy_, (dfdy_dim1, dfdy_dim2,), own=false)
@@ -878,11 +878,11 @@ end
   This is the boundary-conditions function given as callback
   to bvpm2 in the case with no unknown parameters.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_bvpm2_bc_cb(
-     ya_len::Int64, ya_::Ptr{Float64}, 
+     ya_len::Int64, ya_::Ptr{Float64},
      yb_len::Int64, yb_::Ptr{Float64},
      bca_len::Int64, bca_::Ptr{Float64},
      bcb_len::Int64, bcb_::Ptr{Float64}, cbi::CI) where CI<:Bvpm2_solve_cbi
@@ -908,11 +908,11 @@ end
   This is the boundary-conditions function given as callback
   to bvpm2 in the case with unknown parameters.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_bvpm2_bcpar_cb(
-     ya_len::Int64, ya_::Ptr{Float64}, 
+     ya_len::Int64, ya_::Ptr{Float64},
      yb_len::Int64, yb_::Ptr{Float64},
      p_len::Int64, p_::Ptr{Float64},
      bca_len::Int64, bca_::Ptr{Float64},
@@ -941,7 +941,7 @@ end
 """
   This function calls `Dbc` saved in Bvpm2_solve_cbi.
   """
-function bvpm2_Dbc(ya, yb, dya, dyb, cbi::CI, 
+function bvpm2_Dbc(ya, yb, dya, dyb, cbi::CI,
       p=nothing, dpa=nothing, dpb=nothing) where CI
   lprefix = cbi.bc_lprefix
   (lio,l)=(cbi.logio,cbi.loglevel)
@@ -954,7 +954,7 @@ function bvpm2_Dbc(ya, yb, dya, dyb, cbi::CI,
   else
     cbi.Dbc(ya, yb, dya, dyb, p, dpa, dpb)
   end
-  l_Dbc && println(lio, lprefix, "bc result: dya", dya, " dyb=", dyb, 
+  l_Dbc && println(lio, lprefix, "bc result: dya", dya, " dyb=", dyb,
     " dpa=", dpa, " dpb=", dpb)
   return nothing
 end
@@ -963,19 +963,19 @@ end
   This is the derivative of the boundary-conditions given as callback
   to bvpm2 in the case with no unknown parameters.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_bvpm2_Dbc_cb(
   ya_len::Int64, ya_::Ptr{Float64}, yb_len::Int64, yb_::Ptr{Float64},
   dya_dim1::Int64, dya_dim2::Int64, dya_::Ptr{Float64},
-  dyb_dim1::Int64, dyb_dim2::Int64, dyb_::Ptr{Float64}, 
+  dyb_dim1::Int64, dyb_dim2::Int64, dyb_::Ptr{Float64},
   cbi::CI) where CI<:Bvpm2_solve_cbi
 
   @assert ya_len == yb_len == cbi.no_odes
   @assert dya_dim2 == dyb_dim2 == cbi.no_odes
   @assert dya_dim1 == cbi.no_left_bc
-  @assert dyb_dim1 == cbi.no_odes+cbi.no_par-cbi.no_left_bc 
+  @assert dyb_dim1 == cbi.no_odes+cbi.no_par-cbi.no_left_bc
 
   ya = unsafe_wrap(Array, ya_, (ya_len,), own=false)
   yb = unsafe_wrap(Array, yb_, (yb_len,), own=false)
@@ -996,16 +996,16 @@ end
   This is the derivative of the boundary-conditions given as callback
   to bvpm2 in the case with unknown parameters.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_bvpm2_Dbcpar_cb(
   ya_len::Int64, ya_::Ptr{Float64}, yb_len::Int64, yb_::Ptr{Float64},
   p_len::Int64, p_::Ptr{Float64},
   dya_dim1::Int64, dya_dim2::Int64, dya_::Ptr{Float64},
-  dyb_dim1::Int64, dyb_dim2::Int64, dyb_::Ptr{Float64}, 
+  dyb_dim1::Int64, dyb_dim2::Int64, dyb_::Ptr{Float64},
   dpa_dim1::Int64, dpa_dim2::Int64, dpa_::Ptr{Float64},
-  dpb_dim1::Int64, dpb_dim2::Int64, dpb_::Ptr{Float64}, 
+  dpb_dim1::Int64, dpb_dim2::Int64, dpb_::Ptr{Float64},
   cbi::CI) where CI<:Bvpm2_solve_cbi
 
   @assert ya_len == yb_len == cbi.no_odes
@@ -1013,7 +1013,7 @@ function unsafe_bvpm2_Dbcpar_cb(
   @assert dya_dim2 == dyb_dim2 == cbi.no_odes
   @assert dpa_dim2 == dpb_dim2 == cbi.no_par
   @assert dya_dim1 == dpa_dim1 == cbi.no_left_bc
-  @assert dyb_dim1 == dpb_dim1 == cbi.no_odes+cbi.no_par-cbi.no_left_bc 
+  @assert dyb_dim1 == dpb_dim1 == cbi.no_odes+cbi.no_par-cbi.no_left_bc
 
   ya = unsafe_wrap(Array, ya_, (ya_len,), own=false)
   yb = unsafe_wrap(Array, yb_, (yb_len,), own=false)
@@ -1030,13 +1030,13 @@ function unsafe_bvpm2_Dbcpar_cb_c(cbi::CI) where CI
   return @cfunction(unsafe_bvpm2_Dbcpar_cb, Cvoid,
     (Int64, Ptr{Float64}, Int64, Ptr{Float64},
      Int64, Ptr{Float64},
-     Int64, Int64, Ptr{Float64}, Int64, Int64, Ptr{Float64}, 
+     Int64, Int64, Ptr{Float64}, Int64, Int64, Ptr{Float64},
      Int64, Int64, Ptr{Float64}, Int64, Int64, Ptr{Float64}, Ref{CI}))
 end
 
 
 """
-       function bvpm2_solve(guess_obj::Bvpm2, rhs, bc, 
+       function bvpm2_solve(guess_obj::Bvpm2, rhs, bc,
          opt::AbstractOptionsODE) -> (obj_out, retcode, stats)
 
   ## Right-hand side for the ODEs: `rhs`
@@ -1081,7 +1081,7 @@ end
 
   where
 
-        ya::Vector{Float64}(no_odes), yb::Vector{Float64}(no_odes), 
+        ya::Vector{Float64}(no_odes), yb::Vector{Float64}(no_odes),
         p::Vector{Float64}(no_par),
         bca::Vector{Float64}(no_left_bc),
         bcb::Vector{Float64}(no_odes - no_left_bc)
@@ -1100,20 +1100,20 @@ end
 
   where
 
-        ya::Vector{Float64}(no_odes), yb::Vector{Float64}(no_odes), 
+        ya::Vector{Float64}(no_odes), yb::Vector{Float64}(no_odes),
         p::Vector{Float64}(no_par),
         dya::Matrix{Float64}(no_left_bc, no_odes)
         dyb::Matrix{Float64}(no_odes+no_par-no_left_bc, no_odes)
         dpa::Matrix{Float64}(no_left_bc, no_par)
         dpb::Matrix{Float64}(no_odes+no_par-no_left_bc, no_par)
 
-  Inside the function, the values of the derivatives of the boundary 
+  Inside the function, the values of the derivatives of the boundary
   conditions must be saved in `dya`, `dyb`, `dpa` and `dpb`.
 
   ## Options `opt`
 
   In `opt` the following options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -1152,7 +1152,7 @@ end
         <0: failure
         ≥0: computation successful
   """
-function bvpm2_solve(guess_obj::Bvpm2, rhs, bc, 
+function bvpm2_solve(guess_obj::Bvpm2, rhs, bc,
   opt::AbstractOptionsODE; Drhs=nothing, Dbc=nothing)
 
   (lio,l,l_g,l_solver,lprefix) = solver_init("bvpm2", opt)
@@ -1200,7 +1200,7 @@ function bvpm2_solve(guess_obj::Bvpm2, rhs, bc,
   catch e
     throw(ArgumentErrorODE("Option '$OPT': Not valid", :opt, e))
   end
-  
+
   error_ret = Vector{Float64}(undef, 5)
   handle_out = [ C_NULL ]
 
@@ -1212,15 +1212,15 @@ function bvpm2_solve(guess_obj::Bvpm2, rhs, bc,
   end
   cbi = nothing; error = 0
   try
-    global bvpm2_global_cbi = cbi = Bvpm2_solve_cbi(lio, l, 
+    global bvpm2_global_cbi = cbi = Bvpm2_solve_cbi(lio, l,
       no_odes, no_par, no_left_bc,
-      rhs, "unsafe_bvpm2_rhs: ", 0, 
+      rhs, "unsafe_bvpm2_rhs: ", 0,
       Drhs !== nothing ? Drhs : dummy_func, "unsafe_bvpm2_Drhs: ", 0,
       bc, "unsafe_bvpm2_b: ", 0,
       Dbc !== nothing ? Dbc : dummy_func, "unsafe_bvpm2_Dbc: ", 0)
 
     if l_solver
-      println(lio, lprefix, "call Fortran bvpm2_solver ", 
+      println(lio, lprefix, "call Fortran bvpm2_solver ",
         guess_obj.method_solve)
     end
 
@@ -1246,7 +1246,7 @@ function bvpm2_solve(guess_obj::Bvpm2, rhs, bc,
        Int64, Int64,                         # trace, error_control
        Int64, Ptr{Float64},                  # error_ret_len, error_ret
        Ref{Bvpm2_solve_cbi},                 # calls_pthrough
-      ), 
+      ),
       guess_obj.handle, handle_out,
       rhs_fcn_ptr, bc_fcn_ptr,
       si_dim, si_matrix,
@@ -1257,7 +1257,7 @@ function bvpm2_solve(guess_obj::Bvpm2, rhs, bc,
       cbi)
 
     if l_solver
-      println(lio, lprefix, "call Fortran bvpm2_solver ", 
+      println(lio, lprefix, "call Fortran bvpm2_solver ",
         guess_obj.method_solve, " returned ",error)
     end
   finally
@@ -1266,7 +1266,7 @@ function bvpm2_solve(guess_obj::Bvpm2, rhs, bc,
 
   error ≠ 0 && throw(InternalErrorODE(string(
     "Internal error during solve call: error = ",error)))
-  
+
   @assert handle_out[1] ≠ C_NULL
   obj_out = Bvpm2(handle_out[1])
   out_details = bvpm2_get_details(obj_out)
@@ -1285,8 +1285,8 @@ function bvpm2_solve(guess_obj::Bvpm2, rhs, bc,
 end
 
 """
-       function bvpm2_extend(sol_obj::Bvpm2, anew, bnew, 
-                yanew::Vector, ybnew::Vector; 
+       function bvpm2_extend(sol_obj::Bvpm2, anew, bnew,
+                yanew::Vector, ybnew::Vector;
                 p_new=[], max_num_subintervals=0)
 
   extends a solution (`state == 2`) to a new interval. Take the
@@ -1302,10 +1302,10 @@ end
 
   A new Bvpm2-object `guess_obj` will be created an returned.
   """
-function bvpm2_extend(sol_obj::Bvpm2, anew, bnew, 
-         yanew::Vector, ybnew::Vector; 
+function bvpm2_extend(sol_obj::Bvpm2, anew, bnew,
+         yanew::Vector, ybnew::Vector;
          p_new::Vector=[], max_num_subintervals=0)
-  
+
   details = bvpm2_check_state(sol_obj, (2,))
   try
     anew = convert(Float64, anew)
@@ -1343,14 +1343,14 @@ function bvpm2_extend(sol_obj::Bvpm2, anew, bnew,
       :max_num_subintervals, e))
   end
   result = [ C_NULL ]
-  error = ccall(sol_obj.method_extend_s, Int64, 
+  error = ccall(sol_obj.method_extend_s, Int64,
     (Ptr{Cvoid}, Ref{Ptr{Cvoid}},     # handle_in, handle_out
      Float64, Float64,                # anew, bnew
      Int64, Ptr{Float64},             # yanew_len, yanew
      Int64, Ptr{Float64},             # ybnew_len, ybnew
      Int64, Ptr{Float64},             # p_len, p
      Int64,),                         # max_num_subintervals
-    sol_obj.handle, result, 
+    sol_obj.handle, result,
     anew, bnew,
     length(yanew), yanew,
     length(ybnew), ybnew,
@@ -1364,10 +1364,10 @@ function bvpm2_extend(sol_obj::Bvpm2, anew, bnew,
 end
 
 """
-       function bvpm2_extend(sol_obj::Bvpm2, anew, bnew, order; 
+       function bvpm2_extend(sol_obj::Bvpm2, anew, bnew, order;
                 p_new::Vector=[], max_num_subintervals=0)
 
-  extends a solution (`state == 2`) to a new interval using 
+  extends a solution (`state == 2`) to a new interval using
   constant (`order==0`) or linear (`order==1`) extrapolation.
 
   You can change the parameter guess also, by using `p_new` and you
@@ -1378,7 +1378,7 @@ end
 
   A new Bvpm2-object `guess_obj` will be created an returned.
   """
-function bvpm2_extend(sol_obj::Bvpm2, anew, bnew, order; 
+function bvpm2_extend(sol_obj::Bvpm2, anew, bnew, order;
          p_new::Vector=[], max_num_subintervals=0)
   details = bvpm2_check_state(sol_obj, (2,))
   try
@@ -1395,7 +1395,7 @@ function bvpm2_extend(sol_obj::Bvpm2, anew, bnew, order;
     order = convert(Int64, order)
     @assert order ∈ (0, 1,)
   catch e
-    throw(ArgumentErrorODE("Cannot convert order to Int64: 0 or 1", 
+    throw(ArgumentErrorODE("Cannot convert order to Int64: 0 or 1",
       :order, e))
   end
   no_odes = details["no_odes"]
@@ -1427,20 +1427,20 @@ function bvpm2_extend(sol_obj::Bvpm2, anew, bnew, order;
 end
 
 """
-       function evalSolution(sol::Bvpm2, x::Real, z::Vector{Float64}, 
+       function evalSolution(sol::Bvpm2, x::Real, z::Vector{Float64},
          dz::Vector{Float64})
 
   Evaluates an already obtained solution `sol` at scalar point `x`.
-  The values of the solution are saved in `z` which must be a 
+  The values of the solution are saved in `z` which must be a
   vector (of length d).
   For the vector `dz` there are two cases: If `dz` is a empty vector (of
   length 0) then the derivates of z are not calculated, otherwise
   `dz` has to be a vector (of length d) where the derivates are
   stored.
   """
-function evalSolution(sol::Bvpm2, x::Real, z::Vector{Float64}, 
+function evalSolution(sol::Bvpm2, x::Real, z::Vector{Float64},
   dz::Vector{Float64}=Vector{Float64}(undef, 0))
-  
+
   details = bvpm2_check_state(sol, (2,))
   no_odes = details["no_odes"]
   length(z) ≠ no_odes && throw(ArgumentErrorODE(string(
@@ -1467,7 +1467,7 @@ end
 
 """
        function evalSolution(sol::Bvpm2, x::Real)  -> z
-  
+
   Allocates vector `z` and calls `evalSolution(sol, x, z)`.
   """
 function evalSolution(sol::Bvpm2, x::Real)
@@ -1479,40 +1479,40 @@ function evalSolution(sol::Bvpm2, x::Real)
 end
 
 """
-       function evalSolution(sol::Bvpm2, x::Vector{Float64}, 
+       function evalSolution(sol::Bvpm2, x::Vector{Float64},
          z::Matrix{Float64}, dz::Matrix{Float64})
 
   Evaluates an already obtained solution `sol` at scalar point `x`.
-  The values of the solution are saved in `z` which must be a 
+  The values of the solution are saved in `z` which must be a
   vector (of length d).
   For the vector `dz` there are two cases: If `dz` is a empty vector (of
   length 0) then the derivates of z are not calculated, otherwise
   `dz` has to be a vector (of length d) where the derivates are
   stored.
   """
-function evalSolution(sol::Bvpm2, x::Vector{Float64}, z::Matrix{Float64}, 
+function evalSolution(sol::Bvpm2, x::Vector{Float64}, z::Matrix{Float64},
   dz::Matrix{Float64}=Matrix{Float64}(undef, 0,0))
-  
+
   details = bvpm2_check_state(sol, (2,))
   no_odes = details["no_odes"]
   x_len = length(x)
   size(z) ≠ (no_odes, x_len) && throw(ArgumentErrorODE(string(
     "Expected for z a (", no_odes, ", ", x_len, ") matrix, but found a (",
     size(z,1), ", ", size(z,2), ") matrix "), :z))
-  if size(dz) ≠ (0,0) && size(dz) ≠ (no_odes, x_len) 
+  if size(dz) ≠ (0,0) && size(dz) ≠ (no_odes, x_len)
     throw(ArgumentErrorODE(string(
     "Expected for dz an empty matrix or a (", no_odes, ", ", x_len, ") ",
     "matrix, but found a (", size(dz,1), ", ", size(dz,2), ") matrix "), :dz))
   end
   error = ccall(sol.method_eval_v, Int64,
-    (Ptr{Cvoid},                            # handle 
+    (Ptr{Cvoid},                            # handle
      Int64, Ptr{Float64},                  # x_len, x
      Int64, Int64, Ptr{Float64},           # z_dim1, z_dim2
      Int64, Int64, Ptr{Float64},           # dz_dim1, dz_dim2
     ),
     sol.handle,
     length(x), x,
-    size(z, 1), size(z, 2), z, 
+    size(z, 1), size(z, 2), z,
     size(dz, 1), size(dz, 2), dz
     )
 
@@ -1535,7 +1535,7 @@ function evalSolution(sol::Bvpm2, x::Vector{Float64})
   return z
 end
 
-"""  
+"""
   ## Compile BVP_M-2
 
   The julia ODEInterface tries to compile and link the solvers
@@ -1544,33 +1544,33 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
+
        http://cs.stmarys.ca/~muir/BVP_SOLVER_Webpage.shtml
-  
+
   See `help_bvpm3_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile BVP_M-2 with `Float64` reals (and
   `Int64` integers with `gfortran`):
 
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o bvp_la-2.o bvp_la-2.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o bvp_m-2.o bvp_m-2.f90
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o bvp_m_proxy.o bvp_m_proxy.f90
 
   The last file `bvp_m_proxy.f90` is a Julia/C-Proxy and is part of this
   `ODEInterface` package.
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
-       gfortran -shared -fPIC -o bvp_m_proxy.so 
+       gfortran -shared -fPIC -o bvp_m_proxy.so
                 bvp_m_proxy.o bvp_m-2.o bvp_la-2.o
   """
 function help_bvpm2_compile()
@@ -1588,7 +1588,7 @@ function help_bvpm2_proxy()
     while !eof(fh)
       line = readline(fh)
       if length(line) > 0 && line[1] == '!'
-        markdown *= line[ 
+        markdown *= line[
           ((length(line) > 1 && line[2] == ' ') ? 3 : 2):end ] * "\n"
       else
         break
@@ -1606,7 +1606,7 @@ end
   Jason Boisvert, Ray Spiteri, Department of Computer Science, University of Saskatchewan.
   Paul Muir, Mathematics and Computing Science, Saint Mary's University.
   All rights reserved.
- 
+
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
       * Redistributions of source code must retain the above copyright
@@ -1614,10 +1614,10 @@ end
       * Redistributions in binary form must reproduce the above copyright
         notice, this list of conditions and the following disclaimer in the
         documentation and/or other materials provided with the distribution.
-      * Neither Saint Mary's University nor Southern Methodist University nor 
+      * Neither Saint Mary's University nor Southern Methodist University nor
         the names of its contributors may be used to endorse or promote products
         derived from this software without specific prior written permission.
- 
+
   THIS SOFTWARE IS PROVIDED BY Jason Boisvert, Paul Muir, and Ray Spiteri ''AS IS'' AND ANY
   EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -1628,15 +1628,15 @@ end
   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
+
   See documentation below for FUNCTION BVP_SOLVER for a description of the changes
-  to the argument list for BVP_SOLVER. 
- 
+  to the argument list for BVP_SOLVER.
+
   Copyright (c) 2006, Paul Muir and Larry Shampine.
   Paul Muir, Mathematics and Computing Science, Saint Mary's University.
   Larry Shampine, Mathematics, Southern Methodist University.
   All rights reserved.
- 
+
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
       * Redistributions of source code must retain the above copyright
@@ -1644,10 +1644,10 @@ end
       * Redistributions in binary form must reproduce the above copyright
         notice, this list of conditions and the following disclaimer in the
         documentation and/or other materials provided with the distribution.
-      * Neither Saint Mary's University nor Southern Methodist University nor 
+      * Neither Saint Mary's University nor Southern Methodist University nor
         the names of its contributors may be used to endorse or promote products
         derived from this software without specific prior written permission.
- 
+
   THIS SOFTWARE IS PROVIDED BY Paul Muir and Larry Shampine ''AS IS'' AND ANY
   EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -1658,8 +1658,8 @@ end
   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
-  L.F. Shampine, P.H. Muir, H. Xu, A user-friendly Fortran BVP solver, 
+
+  L.F. Shampine, P.H. Muir, H. Xu, A user-friendly Fortran BVP solver,
   J. Numer. Anal. Indust. Appl. Math., 1, 2006, 201--217.
   """
 function help_bvpm2_license()
@@ -1677,15 +1677,15 @@ push!(solverInfo,
       SolverVariant("bvpm2_i64",
         "Bvpm2 with 64bit integers",
         DL_BVPM2,
-        tuple("create_sol_wrapper_c", 
+        tuple("create_sol_wrapper_c",
               "copy_sol_wrapper_c",
               "terminate_sol_wrapper_c",
-              "destroy_sol_wrapper_c", 
-              "show_sol_wrapper_c", 
-              "get_sol_wrapper_details_c", 
+              "destroy_sol_wrapper_c",
+              "show_sol_wrapper_c",
+              "get_sol_wrapper_details_c",
               "get_sol_wrapper_x_c",
-              "init_guess1_c", 
-              "init_guess2_c", 
+              "init_guess1_c",
+              "init_guess2_c",
               "init_guess3_c",
               "solve_c",
               "eval_s_sol_c",

--- a/src/Bvpm2.jl
+++ b/src/Bvpm2.jl
@@ -1582,7 +1582,7 @@ end
   of the Fortran-Proxy written for BVP_M-2.
   """
 function help_bvpm2_proxy()
-  src_file = joinpath(guess_path_of_module(), "bvp_m_proxy.f90")
+  src_file = joinpath(@__DIR__, "bvp_m_proxy.f90")
   markdown = ""
   fh = open(src_file, "r")
     while !eof(fh)

--- a/src/Bvpsol.jl
+++ b/src/Bvpsol.jl
@@ -32,17 +32,17 @@ end
 
 @doc """
   The ode-solver to use for the initial value problems.
-  """ 
+  """
 ODE_SOLVER_USAGE
 
 @doc """
   Use the DIFEX1-solver builtin in bvpsol.
-  """ 
+  """
 ODE_SOLVER_INTERNAL
 
 @doc """
   Use the julia-function for solving the initial value problems.
-  """ 
+  """
 ODE_SOLVER_JULIA
 
 
@@ -54,12 +54,12 @@ bvpsol_global_cbi = nothing
 
 """
   Type encapsulating all required data for Bvpsol-Callbacks.
-  
+
   Unfortunately bvpsol.f does not support passthrough arguments.
-  
+
   We have the typical calling stack:
 
-       bvpsol       
+       bvpsol
            ccall( BVPSOL_  ... )
               ┌───────────────────────────────────────────┐  ⎫
               │unsafe_bvpsolrhs                           │  ⎬ cb. rhs
@@ -79,7 +79,7 @@ mutable struct BvpsolInternalCallInfos{FInt<:FortranInt, RHS_F,
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
   # RHS:
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   # BC:
@@ -116,19 +116,19 @@ mutable struct BvpsolArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{F
 end
 
 """
-       function unsafe_bvpsolrhs(n_::Ptr{FInt}, t_::Ptr{Float64}, 
+       function unsafe_bvpsolrhs(n_::Ptr{FInt}, t_::Ptr{Float64},
                x_::Ptr{Float64}, f_::Ptr{Float64}) where FInt<:FortranInt
-  
+
   This is the right-hand side given as callback to bvpsol.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
-  
+
   uses hw1rhs
   """
-function unsafe_bvpsolrhs(n_::Ptr{FInt}, t_::Ptr{Float64}, 
+function unsafe_bvpsolrhs(n_::Ptr{FInt}, t_::Ptr{Float64},
         x_::Ptr{Float64}, f_::Ptr{Float64}) where FInt<:FortranInt
-  
+
   n = unsafe_load(n_); t = unsafe_load(t_)
   x = unsafe_wrap(Array, x_,(n,), own=false)
   f = unsafe_wrap(Array, f_,(n,), own=false)
@@ -147,15 +147,15 @@ end
 
 """
         function bvpsolbc{CI}(xa,xb,r,cbi::CI)
-  
+
   This function calls `bc` saved in `BvpsolInternalCallInfos`.
   """
 function bvpsolbc(xa,xb,r,cbi::CI) where CI
   lprefix = cbi.bc_lprefix
-  
+
   (lio,l)=(cbi.logio,cbi.loglevel)
   l_bc = l & LOG_BC > 0
-  
+
   l_bc && println(lio,lprefix,"called with xa=",xa," xb=",xb)
   cbi.bc(xa,xb,r)
   l_bc && println(lio,lprefix,"bc result=",r)
@@ -163,17 +163,17 @@ function bvpsolbc(xa,xb,r,cbi::CI) where CI
 end
 
 """
-       function unsafe_bvpsolbc(xa_::Ptr{Float64}, xb_::Ptr{Float64}, 
+       function unsafe_bvpsolbc(xa_::Ptr{Float64}, xb_::Ptr{Float64},
          r_::Ptr{Float64}) -> nothing
-  
+
   This is the callback for the boundary conditions given to bvpsol.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
-  
+
   uses bvpsolbc
   """
-function unsafe_bvpsolbc(xa_::Ptr{Float64}, xb_::Ptr{Float64}, 
+function unsafe_bvpsolbc(xa_::Ptr{Float64}, xb_::Ptr{Float64},
   r_::Ptr{Float64})
 
   cbi = bvpsol_global_cbi :: BvpsolInternalCallInfos
@@ -189,7 +189,7 @@ end
         function unsafe_bvpsolbc_c()
   """
 function unsafe_bvpsolbc_c()
-  return @cfunction(unsafe_bvpsolbc, Cvoid, 
+  return @cfunction(unsafe_bvpsolbc, Cvoid,
         (Ptr{Float64},Ptr{Float64},Ptr{Float64}))
 end
 
@@ -202,16 +202,16 @@ function bvpsolivp(t::Vector{Float64},
   (lio,l)=(cbi.logio,cbi.loglevel)
   lprefix = cbi.ivp_lprefix
   l_ivp = l & LOG_BVPIVPSOL > 0
-  
+
   opt = cbi.odeopt
-  setOptions!(opt, 
-    OPT_RTOL => tol, OPT_MAXSS => hmax, 
+  setOptions!(opt,
+    OPT_RTOL => tol, OPT_MAXSS => hmax,
     OPT_INITIALSS => h[1], "KFLAG" => kflag[1])
-  
+
   l_ivp && println(lio,lprefix,"calling ivp solver with rhs=",cbi.rhs,
     " tStart=",t[1]," tEnd=",tend," x=",x," opt=",opt)
-  
-  (ret_t, ret_x, ret_code, ret_stats) = 
+
+  (ret_t, ret_x, ret_code, ret_stats) =
     cbi.odesol_julia(cbi.rhs,t[1],tend,x,opt)
   l_ivp && println(lio,lprefix,"ivp solver returned ret_t=",ret_t,
     " ret_x=",ret_x," ret_code=",ret_code," ret_stats=",ret_stats)
@@ -228,26 +228,26 @@ function bvpsolivp(t::Vector{Float64},
     h[1] = 0
   end
   l_ivp && println(lio,lprefix,"returning h=",h[1]," kflag=",kflag[1])
-  
+
   return nothing
 end
 
 """
-       function unsafe_bvpsolivp(n_::Ptr{FInt}, 
-               fcn_::Ptr{Cvoid}, t_::Ptr{Float64}, x_::Ptr{Float64}, 
-               tend_::Ptr{Float64}, tol_::Ptr{Float64}, hmax_::Ptr{Float64}, 
+       function unsafe_bvpsolivp(n_::Ptr{FInt},
+               fcn_::Ptr{Cvoid}, t_::Ptr{Float64}, x_::Ptr{Float64},
+               tend_::Ptr{Float64}, tol_::Ptr{Float64}, hmax_::Ptr{Float64},
                h_::Ptr{Float64}, kflag_::Ptr{FInt}) where FInt<:FortranInt
 
   This is the callback for bvpsol to solve initial value problems.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
-  
+
   uses bvpsolivp
   """
-function unsafe_bvpsolivp(n_::Ptr{FInt}, 
-        fcn_::Ptr{Cvoid}, t_::Ptr{Float64}, x_::Ptr{Float64}, 
-        tend_::Ptr{Float64}, tol_::Ptr{Float64}, hmax_::Ptr{Float64}, 
+function unsafe_bvpsolivp(n_::Ptr{FInt},
+        fcn_::Ptr{Cvoid}, t_::Ptr{Float64}, x_::Ptr{Float64},
+        tend_::Ptr{Float64}, tol_::Ptr{Float64}, hmax_::Ptr{Float64},
         h_::Ptr{Float64}, kflag_::Ptr{FInt}) where FInt<:FortranInt
 
   cbi = bvpsol_global_cbi::BvpsolInternalCallInfos
@@ -255,7 +255,7 @@ function unsafe_bvpsolivp(n_::Ptr{FInt},
   t = unsafe_wrap(Array, t_, (1,), own=false)
   tend = unsafe_load(tend_)
   x = unsafe_wrap(Array, x_, (n,), own=false)
-  tol = unsafe_load(tol_); hmax = unsafe_load(hmax_); 
+  tol = unsafe_load(tol_); hmax = unsafe_load(hmax_);
   h = unsafe_wrap(Array, h_, (1,), own=false)
   kflag = unsafe_wrap(Array, kflag_, (1,), own=false)
   bvpsolivp(t,x,tend,tol,hmax,h,kflag,cbi)
@@ -263,7 +263,7 @@ function unsafe_bvpsolivp(n_::Ptr{FInt},
 end
 
 function unsafe_bvpsolivp_c(fint_flag::FInt) where FInt
-  return @cfunction(unsafe_bvpsolivp, Cvoid, 
+  return @cfunction(unsafe_bvpsolivp, Cvoid,
     (Ptr{FInt},Ptr{Cvoid},Ptr{Float64},
     Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},Ptr{Float64},
     Ptr{FInt}))
@@ -278,30 +278,30 @@ end
        function bvpsol(rhs, bc,
          t::Vector, x::Matrix, odesolver, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
-  
+
   The `bc` has to be a function of the following form:
 
        function bc(xa,xb,r) -> nothing
-  
+
   It has to calculate the residual for the boundary conditions and save
   them in `r`.
-  
+
   `t` is a Vector with all the multiple-shooting nodes.
-  
+
   `x` gives the initial guess for all multiple-shooting nodes. Hence
   `size(x,2)==length(t)`.
-  
+
   `odesolver`: Either `nothing`: then the internal solver of `bvpsol` is
-  used. Or `odesolver` is a ode-solver (like `dopri5`, `dop853`, `seulex`, 
+  used. Or `odesolver` is a ode-solver (like `dopri5`, `dop853`, `seulex`,
   etc.).
 
   `retcode` can have the following values:
 
         >0: computation successful: number of iterations
         -1:        Iteration stops at stationary point for OPT_SOLMETHOD==0
-                   Gaussian elimination failed due to singular 
+                   Gaussian elimination failed due to singular
                    Jacobian for OPT_SOLMETHOD==1
-        -2: Iteration stops after OPT_MAXSTEPS 
+        -2: Iteration stops after OPT_MAXSTEPS
         -3: Integrator failed to complete the trajectory
         -4: Gauss Newton method failed to converge
         -5: Given initial values inconsistent with separable linear bc
@@ -314,9 +314,9 @@ end
         -9: Sparse linear solver failed
        -10: Real or integer work-space exhausted
        -11: Rank reduction failed - resulting rank is zero
- 
+
   In `opt` the following options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -358,11 +358,11 @@ end
   """
 function bvpsol_i32(rhs, bc,
   t::Vector, x::Matrix, odesolver, opt::AbstractOptionsODE)
-  return bvpsol_impl(rhs,bc,t,x,odesolver,opt,BvpsolArguments{Int32}(Int32(0))) 
+  return bvpsol_impl(rhs,bc,t,x,odesolver,opt,BvpsolArguments{Int32}(Int32(0)))
 end
 
 function bvpsol_impl(rhs, bc,
-  t::Vector, x::Matrix, odesolver, 
+  t::Vector, x::Matrix, odesolver,
   opt::AbstractOptionsODE, args::BvpsolArguments{FInt}) where FInt<:FortranInt
 
   (lio,l,l_g,l_solver,lprefix) = solver_init("bvpsol",opt)
@@ -375,7 +375,7 @@ function bvpsol_impl(rhs, bc,
 
   (method_bvpsol, method_bldfx1) = getAllMethodPtrs(
      (FInt == Int64) ? DL_BVPSOL : DL_BVPSOL_I32 )
-  
+
   d = FInt(0)
   try
     d = convert(FInt,size(x,1))
@@ -384,7 +384,7 @@ function bvpsol_impl(rhs, bc,
   end
   0==d && throw(ArgumentErrorODE("x has no rows",:x))
   N=d; args.N = [d]
-  
+
   m = FInt(0)
   try
     m = convert(FInt,size(x,2))
@@ -398,13 +398,13 @@ function bvpsol_impl(rhs, bc,
     throw(ArgumentErrorODE("size(x,2) ≠ length(t)",:t,e))
   end
   M = m; args.M = [m]
-  
+
   try
     args.T = getVectorCheckLength(t,Float64,m);
   catch e
     throw(ArgumentErrorODE("cannot convert t to Vector{Float64}",:t,e))
   end
-  
+
   try
     args.X = getMatrixCheckSize(x,Float64,d,m)
   catch e
@@ -414,14 +414,14 @@ function bvpsol_impl(rhs, bc,
   rhs_mode = solver_extract_rhsMode(opt)
   rhs_lprefix = "unsafe_bvpsolrhs: "
   bc_lprefix = "unsafe_bvpsolbc: "
-  
+
   try
     args.EPS = [ convert(Float64,getOption(opt,OPT_RTOL,1e-6)) ]
     @assert 0 < args.EPS[1] <= 1.0e-2
   catch e
     throw(ArgumentErrorODE("Cannot convert OPT_RTOL to Float64",:opt,e))
   end
-  
+
   args.IOPT = Vector{FInt}(undef, 6)
   ivpopt = nothing
   ivp_lprefix = "unsafe_bvpsolivp: "
@@ -429,15 +429,15 @@ function bvpsol_impl(rhs, bc,
   try
     OPT = OPT_MAXSTEPS; args.IOPT[1] = convert(FInt,getOption(opt,OPT,40))
     @assert args.IOPT[1] > 0
-    
+
     OPT = OPT_BVPCLASS; args.IOPT[2] = convert(FInt,getOption(opt,OPT,2))
     @assert 0 ≤ args.IOPT[2] ≤ 3
-    
+
     OPT = OPT_SOLMETHOD; args.IOPT[3] = convert(FInt,getOption(opt,OPT,0))
     @assert 0 ≤ args.IOPT[3] ≤ 1
-    
+
     args.IOPT[4] = -1; args.IOPT[5] = 0;
-    
+
     OPT = OPT_IVPOPT; ivpopt = getOption(opt,OPT,nothing)
     if ivpopt === nothing
       ivpopt = OptionsODE("Autogenerated by bvpsol")
@@ -446,7 +446,7 @@ function bvpsol_impl(rhs, bc,
   catch e
     throw(ArgumentErrorODE("Option '$OPT': Not valid",:opt,e))
   end
-  
+
   if     args.IOPT[3]==0
     args.IIW = [ FInt(4*N + 2*N*N) ]
     args.IRW = [ FInt(N*N*(M+5) + 10*M*N + 10*N +M) ]
@@ -480,22 +480,22 @@ function bvpsol_impl(rhs, bc,
       "support 'pass-through' arguments. Hence this julia module does not ",
       "support concurrent/nested bvpsol calls. Sorry."), :opt))
   end
-  
+
   try
     global bvpsol_global_cbi = BvpsolInternalCallInfos(lio,l,rhs,rhs_mode,
-        rhs_lprefix, bc,bc_lprefix,N, 
+        rhs_lprefix, bc,bc_lprefix,N,
         odesolver === nothing ? ODE_SOLVER_INTERNAL : ODE_SOLVER_JULIA,
         odesolver === nothing ? bvpsol_ivp_dummy : odesolver,
         ivpopt, ivp_lprefix)
-    
+
     if l_solver
       println(lio,lprefix,"call Fortran-bvpsol $method_bvpsol with")
       dump(lio,args)
     end
-    
+
     ccall( method_bvpsol, Cvoid,
       (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid},        # Rightsidefunc, BC, IVPSOL
-       Ptr{FInt}, Ptr{FInt},                      # N, M 
+       Ptr{FInt}, Ptr{FInt},                      # N, M
        Ptr{Float64}, Ptr{Float64}, Ptr{Float64},  # t, x, EPS
        Ptr{FInt}, Ptr{FInt},                      # IOPT, INFO
        Ptr{FInt}, Ptr{Float64},                   # IRW, RW
@@ -508,7 +508,7 @@ function bvpsol_impl(rhs, bc,
       args.IRW, args.RW,
       args.IIW, args.IW,
     )
-    
+
     if l_solver
       println(lio,lprefix,"Fortran-bvpsol $method_bvpsol returned")
       dump(lio,args)
@@ -522,7 +522,7 @@ function bvpsol_impl(rhs, bc,
 end
 
 
-"""  
+"""
   ## Compile BVPSOL
 
   The julia ODEInterface tries to compile and link the solvers
@@ -531,102 +531,102 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
+
        http://elib.zib.de/pub/elib/codelib/bvpsol/
-  
+
   See `help_bvpsol_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile BVPSOL with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o bvpsol.o bvpsol.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o linalg_bvpsol.o linalg_bvpsol.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o zibconst.o zibconst.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o ma28_bvpsol.o ma28_bvpsol.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
-       gfortran -shared -fPIC -o bvpsol.so 
+       gfortran -shared -fPIC -o bvpsol.so
                 bvpsol.o linalg_bvpsol.o zibconst.o ma28_bvpsol.o
        gfortran -shared -fPIC -o bvpsol.dylib
                 bvpsol.o linalg_bvpsol.o zibconst.o ma28_bvpsol.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile BVPSOL with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o bvpsol.o bvpsol.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o linalg_bvpsol.o linalg_bvpsol.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o zibconst.o zibconst.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o ma28_bvpsol.o ma28_bvpsol.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
-       gfortran -shared -o bvpsol.so 
+
+       gfortran -shared -o bvpsol.so
                 bvpsol.o linalg_bvpsol.o zibconst.o ma28_bvpsol.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile BVPSOL with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o bvpsol_i32.o bvpsol.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o linalg_bvpsol_i32.o linalg_bvpsol.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
-                -o zibonst_i32.o zibconst.f 
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
-                -o ma28_bvpsol_i32.o ma28_bvpsol.f 
-  
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
+                -o zibonst_i32.o zibconst.f
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
+                -o ma28_bvpsol_i32.o ma28_bvpsol.f
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
-       gfortran -shared -fPIC -o bvpsol_i32.so 
+
+       gfortran -shared -fPIC -o bvpsol_i32.so
                  bvpsol_i32.o linalg_bvpsol_i32.o zibconst_i32.o ma28_bvpsol_i32.o
        gfortran -shared -fPIC -o bvpsol_i32.dylib
                  bvpsol_i32.o linalg_bvpsol_i32.o zibconst_i32.o ma28_bvpsol_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile BVPSOL with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o bvpsol_i32.o bvpsol.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o linalg_bvpsol_i32.o linalg_bvpsol.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
-                -o zibconst_i32.o zibconst.f 
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
-                -o ma28_bvpsol_i32.o ma28_bvpsol.f 
-  
+       gfortran -c -fdefault-real-8 -fdefault-double-8
+                -o zibconst_i32.o zibconst.f
+       gfortran -c -fdefault-real-8 -fdefault-double-8
+                -o ma28_bvpsol_i32.o ma28_bvpsol.f
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o bvpsol_i32.dll
                  bvpsol_i32.o linalg_bvplsol_i32.o zibconst_i32.o
                  ma28_bvpsol_i32.o
-  
+
   """
 function help_bvpsol_compile()
   return Docs.doc(help_bvpsol_compile)
@@ -642,7 +642,7 @@ end
   Berlin (ZIB).
   In case you intend to use the code commercially, we oblige you
   to sign an according licence agreement with ZIB.
-  
+
   # Warranty
   This code has been tested up to a certain level. Defects and
   weaknesses, which may be included in the code, do not establish

--- a/src/Call.jl
+++ b/src/Call.jl
@@ -17,7 +17,7 @@ const solvers_outputattimes = (ddeabm, ddeabm_i32, ddebdf, ddebdf_i32)
       function odecall(solver, rhs, t::Vector, x0::Vector,
                       opt::AbstractOptionsODE)
           -> (tVec,xVec,retcode,stats)
-  
+
   Calls `solver` with the given right-hand side `rhs`.
   There are two cases:
 
@@ -28,17 +28,17 @@ const solvers_outputattimes = (ddeabm, ddeabm_i32, ddebdf, ddebdf_i32)
   (adaptive) solver has automatically chosen. And the `xVec` has the
   states at this times. So: `tVec` is a `Vector{Float64}(m)` and
   `xVec` is a `Array{Float64}(m,length(x0))`.
-  
+
   If `2<length(t)`, then the values in `t` must be strictly ascending
   or strictly descending. Then a special output function is used to get
   the numerical solution at the given `t`-values. In this case
   `tVec` is a `Vector{Float64}(length(t))` and
   `xVec` is a `Array{Float64}(length(t),length(x0))`.
-  
+
   If in `opt` a output function is given, then this output function is
   also called/used.
   """
-function odecall(solver, rhs, t::Vector, x0::Vector, 
+function odecall(solver, rhs, t::Vector, x0::Vector,
                  opt::AbstractOptionsODE)
   tLen = length(t)
   tLen < 2 && throw(ArgumentErrorODE(
@@ -55,7 +55,7 @@ function odecall(solver, rhs, t::Vector, x0::Vector,
   locopt = OptionsODE(opt)
   orig_outputfcn = getOption(opt, OPT_OUTPUTFCN, nothing)
   orig_outputmode = getOption(opt, OPT_OUTPUTMODE, OUTPUTFCN_NEVER)
-  
+
   if 2==tLen
     tVec = Vector{Float64}()    # we do not know how many steps/points
     xVec = Vector{Float64}()    # the solver will use => tVec and xVec grow
@@ -65,7 +65,7 @@ function odecall(solver, rhs, t::Vector, x0::Vector,
     #             NEVER   │       WODENSE
     #            WODENSE  │       WODENSE
     #             DENSE   │       DENSE
-    orig_outputmode != OUTPUTFCN_DENSE && 
+    orig_outputmode != OUTPUTFCN_DENSE &&
       setOption!(locopt,OPT_OUTPUTMODE,OUTPUTFCN_WODENSE)
 
     # save only grid points of solver in tVec, xVec
@@ -113,8 +113,8 @@ function odecall(solver, rhs, t::Vector, x0::Vector,
     function outputfcn_givent(reason::OUTPUTFCN_CALL_REASON,
           told::Float64, tnew::Float64, x::Vector{Float64},
           eval_sol_fcn::Function, extra_data::Dict)
-      
-      if (reason == OUTPUTFCN_CALL_STEP) 
+
+      if (reason == OUTPUTFCN_CALL_STEP)
         while (tPos ≤ tLen) &&
               ( (told ≤ t[tPos] ≤ tnew) || (told ≥ t[tPos] ≥ tnew) )
           tVec[tPos] = t[tPos]
@@ -137,9 +137,9 @@ function odecall(solver, rhs, t::Vector, x0::Vector,
       setOption!(locopt,OPT_OUTPUTFCN, outputfcn_givent)
     end
   end
-  
+
   (tout,xout,retcode,stats) = solver( rhs, t0, T, x0, locopt)
-  
+
   return (tVec, transpose(reshape(xVec,d,length(xVec)÷d)), retcode, stats)
 
 end

--- a/src/Colnew.jl
+++ b/src/Colnew.jl
@@ -36,13 +36,13 @@ colnew_global_cbi = nothing
 
 """
   Type encapsulating all required data for colnew-Callbacks.
-  
+
   Unfortunately colnew.f does not support passthrough arguments.
-  
+
   We have the typical calling stack:
 
   """
-mutable struct ColnewInternalCallInfos{FInt<:FortranInt, 
+mutable struct ColnewInternalCallInfos{FInt<:FortranInt,
         RHS_F, DRHS_F, BC_F, DBC_F, GUESS_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
@@ -116,20 +116,20 @@ function colnew_rhs(t, z, f, cbi::CI) where CI
 end
 
 """
-        function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64}, 
+        function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64},
           f_::Ptr{Float64})
 
   This is the right-hand side given as callback to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
-function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64}, 
+function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64},
   f_::Ptr{Float64})
 
   cbi = colnew_global_cbi :: ColnewInternalCallInfos
   n = cbi.n; d = cbi.d
-  
+
   t = unsafe_load(t_)
   z = unsafe_wrap(Array, z_, (d,), own=false)
   f = unsafe_wrap(Array, f_, (n,), own=false)
@@ -139,7 +139,7 @@ function unsafe_colnew_rhs(t_::Ptr{Float64}, z_::Ptr{Float64},
 end
 
 function unsafe_colnew_rhs_c(fint_flag::FInt) where FInt
-  return @cfunction(unsafe_colnew_rhs, Cvoid, 
+  return @cfunction(unsafe_colnew_rhs, Cvoid,
     (Ptr{Float64}, Ptr{Float64}, Ptr{Float64}))
 end
 
@@ -165,7 +165,7 @@ end
 
   This is the Jacobian for the right-hand side given as callback to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_colnew_Drhs(t_::Ptr{Float64}, z_::Ptr{Float64},
@@ -210,7 +210,7 @@ end
   This is the side-/boundary-conditions given as callback
   to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_colnew_bc(i_::Ptr{FInt},
@@ -255,7 +255,7 @@ end
   This is the jacobian for the side-/boundary-conditions given as callback
   to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_colnew_Dbc(i_::Ptr{FInt},
@@ -294,7 +294,7 @@ end
 """
   This is the guess function given as callback to colnew.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_colnew_guess(t_::Ptr{Float64}, z_::Ptr{Float64},
@@ -372,7 +372,7 @@ end
       function rhs(t, z, f)
 
   with the input data: t (scalar) time and z∈ℝᵈ (z=z(x(t))).
-  The values of the right-hand side have to be saved in f: f∈ℝⁿ! 
+  The values of the right-hand side have to be saved in f: f∈ℝⁿ!
   Only the non-trivial parts of the right-hand side must be calculated.
 
   ## Drhs
@@ -406,7 +406,7 @@ end
       function Dbc(i, z, dbc)
 
   with the input data: integer index i and z∈ℝᵈ (z=z(x(t))).
-  The  values of the derivative of the i-th side-condition 
+  The  values of the derivative of the i-th side-condition
   (at time ζ(i)) has to be saved in dbc:
 
                 ∂bcᵢ
@@ -433,7 +433,7 @@ end
 
   ## return values
 
-  `sol` is a solution object which can be evaluated with the 
+  `sol` is a solution object which can be evaluated with the
   `evalSolution` functions. Or you can ask for the (final) grid
   of the solution with `getSolutionGrid`.
 
@@ -447,7 +447,7 @@ end
         -3: there is an input data error
 
   In `opt` the following options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -535,7 +535,7 @@ function colnew(interval::Vector, orders::Vector, ζ::Vector,
   rhs, Drhs,
   bc, Dbc, guess, opt::AbstractOptionsODE)
 
-  return colnew_impl(interval, orders, ζ, rhs, Drhs, bc, Dbc, guess, opt, 
+  return colnew_impl(interval, orders, ζ, rhs, Drhs, bc, Dbc, guess, opt,
     ColnewArguments{Int64}(Int64(0)))
 end
 
@@ -546,7 +546,7 @@ function colnew_i32(interval::Vector, orders::Vector, ζ::Vector,
   rhs, Drhs,
   bc, Dbc, guess, opt::AbstractOptionsODE)
 
-  return colnew_impl(interval, orders, ζ, rhs, Drhs, bc, Dbc, guess, opt, 
+  return colnew_impl(interval, orders, ζ, rhs, Drhs, bc, Dbc, guess, opt,
     ColnewArguments{Int32}(Int32(0)))
 end
 
@@ -574,7 +574,7 @@ function colnew_impl(
     t_ab = getVectorCheckLength(interval, Float64, 2)
   catch e
     throw(ArgumentErrorODE(
-      "cannot convert interval to Vector{Float64} with 2 components", 
+      "cannot convert interval to Vector{Float64} with 2 components",
       :interval, e))
   end
   t_ab[1] ≥ t_ab[2] && throw(ArgumentErrorODE(
@@ -635,7 +635,7 @@ function colnew_impl(
     # RTOL ( => ltol, tol)
     OPT = OPT_RTOL
     rtol = getOption(opt, OPT, 1e-6)
-    if isscalar(rtol) 
+    if isscalar(rtol)
       rtol = rtol*ones(Float64, d)
     end
     rtol = getVectorCheckLength(rtol, Float64, d, false)
@@ -652,7 +652,7 @@ function colnew_impl(
       "All components in RTOL were NaN!"), :opt)
     args.IPAR[4] = FInt( length(args.LTOL) )
 
-    OPT = OPT_BVPCLASS; 
+    OPT = OPT_BVPCLASS;
     bvpclass = convert(FInt, getOption(opt, OPT, 1))
     @assert 0 ≤ bvpclass ≤ 3
     args.IPAR[1] = FInt( bvpclass == 0 ? 0 : 1)
@@ -669,12 +669,12 @@ function colnew_impl(
 
     OPT = OPT_SUBINTERVALS
     subintervals = getOption(opt, OPT, 5)
-    if isscalar(subintervals) 
+    if isscalar(subintervals)
       args.IPAR[8] = FInt(0) # uniform(-like) initial grid
       args.IPAR[3] = FInt(subintervals)
       @assert 0 < args.IPAR[3] ≤ max_subintervals
     else
-      subintervals = getVectorCheckLength(subintervals, Float64, 
+      subintervals = getVectorCheckLength(subintervals, Float64,
         length(subintervals)) # always copy
       append!(subintervals, ζ)
       subintervals = unique(sort!(subintervals))
@@ -717,7 +717,7 @@ function colnew_impl(
     nsizef = 4 + 3*d + (5+kd)*kdm + (2*d-nrec)*2*d
 
     args.IPAR[5] = FInt(max_subintervals*nsizef)
-    args.IPAR[6] = FInt(max_subintervals*nsizei) 
+    args.IPAR[6] = FInt(max_subintervals*nsizei)
 
     args.FSPACE = zeros(Float64, args.IPAR[5])
     args.ISPACE = zeros(FInt, args.IPAR[6])
@@ -768,7 +768,7 @@ function colnew_impl(
   end
   cbi = nothing
   try
-    global colnew_global_cbi = cbi = ColnewInternalCallInfos(lio, l, n, d, 
+    global colnew_global_cbi = cbi = ColnewInternalCallInfos(lio, l, n, d,
       rhs, "unsafe_colnewrhs: ", 0,  Drhs, "unsafe_colnew_Drhs: ",0,
       bc, "unsafe_colnew_bc: ", 0,   Dbc, "unsafe_colnew_Dbc: ", 0,
       guess, "unsafe_colnew_guess")
@@ -812,7 +812,7 @@ function colnew_impl(
   end
   l_g && println(lio, lprefix, string("done IFALG=", args.IFLAG[1]))
   solobj = ColnewSolution(
-    method_appsln, t_ab[1], t_ab[2], n, d, 
+    method_appsln, t_ab[1], t_ab[2], n, d,
     args.ISPACE[1:(7+n)],
     args.FSPACE[1:args.ISPACE[7]])
   stats = Dict{AbstractString,Any}(
@@ -830,8 +830,8 @@ end
          t::Real, z::Vector{Float64}) where FInt<:FortranInt
 
   Evaluates an already obtained solution `sol` at time `t`.
-  The values of the solution are saved in `z` which must be a 
-  vector (of length d). 
+  The values of the solution are saved in `z` which must be a
+  vector (of length d).
   `t` must be in the interval [a,b] where the problem was solved.
   """
 function evalSolution(sol::ColnewSolution{FInt},
@@ -849,14 +849,14 @@ function evalSolution(sol::ColnewSolution{FInt},
 end
 
 """
-       function evalSolution(sol::ColnewSolution{FInt}, 
+       function evalSolution(sol::ColnewSolution{FInt},
          t::Real) where FInt<:FortranInt
 
   Evaluates an already obtained solution `sol` at time `t`.
   A newly allocated vector with the solution values is retured.
   `t` must be in the interval [a,b] where the problem was solved.
   """
-function evalSolution(sol::ColnewSolution{FInt}, 
+function evalSolution(sol::ColnewSolution{FInt},
   t::Real) where FInt<:FortranInt
 
   z = Vector{Float64}(undef, sol.d)
@@ -865,16 +865,16 @@ function evalSolution(sol::ColnewSolution{FInt},
 end
 
 """
-        function evalSolution(sol::ColnewSolution{FInt}, 
+        function evalSolution(sol::ColnewSolution{FInt},
           t::Vector) where FInt<:FortranInt
 
   Evaluates an already obtained solution `sol` at time all
   times in the vector `t`.
-  A newly allocated matrix of size `(length(t), d)` with the solution 
+  A newly allocated matrix of size `(length(t), d)` with the solution
   values is retured.
   All values of `t` must be in the interval [a,b] where the problem was solved.
   """
-function evalSolution(sol::ColnewSolution{FInt}, 
+function evalSolution(sol::ColnewSolution{FInt},
   t::Vector) where FInt<:FortranInt
 
   tno = length(t)
@@ -899,7 +899,7 @@ function getSolutionGrid(sol::ColnewSolution{FInt}) where FInt<:FortranInt
 end
 
 
-"""  
+"""
   ## Compile COLNEW
 
   The julia ODEInterface tries to compile and link the solvers
@@ -908,37 +908,37 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
+
        https://people.sc.fsu.edu/~jburkardt/f77_src/colnew/colnew.html
-  
+
   See `help_colnew_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile BVPSOL with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o colnew.o colnew.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
        gfortran -shared -fPIC -o colnew.so colnew.o
        gfortran -shared -fPIC -o colnew.dylib colnew.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile BVPSOL with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o colnew.o colnew.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
+
        gfortran -shared -o colnew.dll colnew.o
   """
 function help_colnew_compile()
@@ -955,104 +955,104 @@ end
   ```
                    GNU LESSER GENERAL PUBLIC LICENSE
                          Version 3, 29 June 2007
-  
+
    Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
    Everyone is permitted to copy and distribute verbatim copies
    of this license document, but changing it is not allowed.
-  
-  
+
+
     This version of the GNU Lesser General Public License incorporates
   the terms and conditions of version 3 of the GNU General Public
   License, supplemented by the additional permissions listed below.
-  
+
     0. Additional Definitions.
-  
+
     As used herein, "this License" refers to version 3 of the GNU Lesser
   General Public License, and the "GNU GPL" refers to version 3 of the GNU
   General Public License.
-  
+
     "The Library" refers to a covered work governed by this License,
   other than an Application or a Combined Work as defined below.
-  
+
     An "Application" is any work that makes use of an interface provided
   by the Library, but which is not otherwise based on the Library.
   Defining a subclass of a class defined by the Library is deemed a mode
   of using an interface provided by the Library.
-  
+
     A "Combined Work" is a work produced by combining or linking an
   Application with the Library.  The particular version of the Library
   with which the Combined Work was made is also called the "Linked
   Version".
-  
+
     The "Minimal Corresponding Source" for a Combined Work means the
   Corresponding Source for the Combined Work, excluding any source code
   for portions of the Combined Work that, considered in isolation, are
   based on the Application, and not on the Linked Version.
-  
+
     The "Corresponding Application Code" for a Combined Work means the
   object code and/or source code for the Application, including any data
   and utility programs needed for reproducing the Combined Work from the
   Application, but excluding the System Libraries of the Combined Work.
-  
+
     1. Exception to Section 3 of the GNU GPL.
-  
+
     You may convey a covered work under sections 3 and 4 of this License
   without being bound by section 3 of the GNU GPL.
-  
+
     2. Conveying Modified Versions.
-  
+
     If you modify a copy of the Library, and, in your modifications, a
   facility refers to a function or data to be supplied by an Application
   that uses the facility (other than as an argument passed when the
   facility is invoked), then you may convey a copy of the modified
   version:
-  
+
      a) under this License, provided that you make a good faith effort to
      ensure that, in the event an Application does not supply the
      function or data, the facility still operates, and performs
      whatever part of its purpose remains meaningful, or
-  
+
      b) under the GNU GPL, with none of the additional permissions of
      this License applicable to that copy.
-  
+
     3. Object Code Incorporating Material from Library Header Files.
-  
+
     The object code form of an Application may incorporate material from
   a header file that is part of the Library.  You may convey such object
   code under terms of your choice, provided that, if the incorporated
   material is not limited to numerical parameters, data structure
   layouts and accessors, or small macros, inline functions and templates
   (ten or fewer lines in length), you do both of the following:
-  
+
      a) Give prominent notice with each copy of the object code that the
      Library is used in it and that the Library and its use are
      covered by this License.
-  
+
      b) Accompany the object code with a copy of the GNU GPL and this license
      document.
-  
+
     4. Combined Works.
-  
+
     You may convey a Combined Work under terms of your choice that,
   taken together, effectively do not restrict modification of the
   portions of the Library contained in the Combined Work and reverse
   engineering for debugging such modifications, if you also do each of
   the following:
-  
+
      a) Give prominent notice with each copy of the Combined Work that
      the Library is used in it and that the Library and its use are
      covered by this License.
-  
+
      b) Accompany the Combined Work with a copy of the GNU GPL and this license
      document.
-  
+
      c) For a Combined Work that displays copyright notices during
      execution, include the copyright notice for the Library among
      these notices, as well as a reference directing the user to the
      copies of the GNU GPL and this license document.
-  
+
      d) Do one of the following:
-  
+
          0) Convey the Minimal Corresponding Source under the terms of this
          License, and the Corresponding Application Code in a form
          suitable for, and under terms that permit, the user to
@@ -1060,14 +1060,14 @@ end
          the Linked Version to produce a modified Combined Work, in the
          manner specified by section 6 of the GNU GPL for conveying
          Corresponding Source.
-  
+
          1) Use a suitable shared library mechanism for linking with the
          Library.  A suitable mechanism is one that (a) uses at run time
          a copy of the Library already present on the user's computer
          system, and (b) will operate properly with a modified version
          of the Library that is interface-compatible with the Linked
          Version.
-  
+
      e) Provide Installation Information, but only if you would otherwise
      be required to provide such information under section 6 of the
      GNU GPL, and only to the extent that such information is
@@ -1079,30 +1079,30 @@ end
      Code. If you use option 4d1, you must provide the Installation
      Information in the manner specified by section 6 of the GNU GPL
      for conveying Corresponding Source.)
-  
+
     5. Combined Libraries.
-  
+
     You may place library facilities that are a work based on the
   Library side by side in a single library together with other library
   facilities that are not Applications and are not covered by this
   License, and convey such a combined library under terms of your
   choice, if you do both of the following:
-  
+
      a) Accompany the combined library with a copy of the same work based
      on the Library, uncombined with any other library facilities,
      conveyed under the terms of this License.
-  
+
      b) Give prominent notice with the combined library that part of it
      is a work based on the Library, and explaining where to find the
      accompanying uncombined form of the same work.
-  
+
     6. Revised Versions of the GNU Lesser General Public License.
-  
+
     The Free Software Foundation may publish revised and/or new versions
   of the GNU Lesser General Public License from time to time. Such new
   versions will be similar in spirit to the present version, but may
   differ in detail to address new problems or concerns.
-  
+
     Each version is given a distinguishing version number. If the
   Library as you received it specifies that a certain numbered version
   of the GNU Lesser General Public License "or any later version"
@@ -1112,14 +1112,14 @@ end
   received it does not specify a version number of the GNU Lesser
   General Public License, you may choose any version of the GNU Lesser
   General Public License ever published by the Free Software Foundation.
-  
+
     If the Library as you received it specifies that a proxy can decide
   whether future versions of the GNU Lesser General Public License shall
   apply, that proxy's public statement of acceptance of any version is
   permanent authorization for you to choose that version for the
   Library.
   ```
-  
+
   """
 function help_colnew_license()
   return Docs.doc(help_colnew_license)
@@ -1129,9 +1129,9 @@ end
 push!(solverInfo,
   SolverInfo("colnew",
     "Multi-Point boundary value solver for mixed order systems with collocation",
-    tuple( :OPT_BVPCLASS, :OPT_RTOL, :OPT_COLLOCATIONPTS, 
-           :OPT_SUBINTERVALS, :OPT_FREEZEINTERVALS, 
-           :OPT_ADDGRIDPOINTS, :OPT_MAXSUBINTERVALS, 
+    tuple( :OPT_BVPCLASS, :OPT_RTOL, :OPT_COLLOCATIONPTS,
+           :OPT_SUBINTERVALS, :OPT_FREEZEINTERVALS,
+           :OPT_ADDGRIDPOINTS, :OPT_MAXSUBINTERVALS,
            :OPT_DIAGNOSTICOUTPUT, :OPT_COARSEGUESSGRID,
           ),
     tuple(
@@ -1151,4 +1151,3 @@ push!(solverInfo,
 
 
 # vim:syn=julia:cc=79:fdm=indent:
-

--- a/src/DLSolvers.jl
+++ b/src/DLSolvers.jl
@@ -40,12 +40,12 @@ global const dlSolversInfo = Dict{AbstractString,SolverDLinfo}()
 
 """
        function trytoloadlib(name::AbstractString,extrapaths::Vector)
-  
+
   tries to (dynamically) load the given shared library given by name.
-  
+
   if `ame="name"` then all the following variants will be tried:
   `"name"`, `"NAME"`, `"Name"`
-  
+
   returns `(ptr,filepath)`
   """
 function trytoloadlib(name::AbstractString,extrapaths::Vector)
@@ -53,7 +53,7 @@ function trytoloadlib(name::AbstractString,extrapaths::Vector)
 
   trylist =  [name, uppercase(name), uppercasefirst(name)]
   filepath = Libdl.find_library(trylist, extrapaths)
-  if isempty(filepath) 
+  if isempty(filepath)
     throw(ErrorException(
       "Cannot find one of $trylist in libpaths or in $extrapaths"))
   end
@@ -66,7 +66,7 @@ end
              method_name::AbstractString) -> (ptr,namefound)
 
   tries to find the given method by name in a dynamically loaded library.
-  
+
   if `method_name="name"` then the following variants will be tried:
   `"name"`, `"NAME"`, `"Name"`,
   `"name_"`, `"NAME_"`, `"Name_"`,
@@ -75,16 +75,16 @@ end
   """
 function trytoloadmethod(libhandle::Ptr{Cvoid},method_name::AbstractString)
   namefound = ""
-  name_vars = ( method_name, uppercase(method_name), 
+  name_vars = ( method_name, uppercase(method_name),
                 uppercasefirst(method_name) )
-  trylist = tuple( 
+  trylist = tuple(
     name_vars...,
     map(x->string(x,"_"),name_vars)...,
     map(x->string("_",x),name_vars)...)
   ptr = C_NULL
   for name in trylist
     ptr = Libdl.dlsym_e(libhandle,name)
-    if (ptr != C_NULL) 
+    if (ptr != C_NULL)
       namefound = name
       break
     end
@@ -97,32 +97,32 @@ end
 """
        function loadODESolvers(extrapaths::Vector=AbstractString[],
                  loadlibnames::Tuple=() )
-                
+
   tries to (dynamically) load the solvers.
-  
+
   additional locations/paths to look at can be given as argument.
-  
+
   If the 1st argument is an empty Vector, then the method tries to
   find the path of the ODEInterface module and (if successfull)
   uses this path as `extrapaths`.
-  
-  The 2nd argument is a `Tuple` with libnames of solvers to load. 
+
+  The 2nd argument is a `Tuple` with libnames of solvers to load.
   If it is an empty tuple, then all known solvers will be tried.
-  
+
   If an solver is already successfully loaded, then it will *not* be
   loaded again.
-  
+
   returns `Dict` with informations about the loaded solvers (and errors).
-  
+
   If a solver cannot be found (or needed methods inside a dynmic library
   cannot be found) then the errors are not propagated to the caller. The
   errors and expections are saved in the returned `Dict`. Why? Using this
   way, it is possible to see with one call (and try to load all solvers)
   which solvers are found.
-  
+
   You can simply `dump` the values of the output dict to get a human-readable
   form of the result or call `help_solversupport()`.
-  
+
        for k in keys(res); dump(res[k]); end
        ODEInterface.help_solversupport()
   """
@@ -135,9 +135,9 @@ function loadODESolvers(extrapaths::Vector=AbstractString[],
     for variant in solver.variants
       libname = variant.libname
       if isempty(loadlibnames) || libname ∈ loadlibnames
-        if !haskey(dlSolversInfo,libname) || 
-           nothing ≠ dlSolversInfo[libname].error 
-           
+        if !haskey(dlSolversInfo,libname) ||
+           nothing ≠ dlSolversInfo[libname].error
+
            libhandle = C_NULL; filepath =""; err = nothing
            mArray = Vector{MethodDLinfo}()
            try
@@ -145,7 +145,7 @@ function loadODESolvers(extrapaths::Vector=AbstractString[],
              for generic_name in variant.methods
                methodsname_found = ""; method_ptr = C_NULL; merr = nothing
                try
-                 (method_ptr, methodsname_found) = 
+                 (method_ptr, methodsname_found) =
                    trytoloadmethod(libhandle, generic_name)
                catch e
                  merr = e
@@ -162,7 +162,7 @@ function loadODESolvers(extrapaths::Vector=AbstractString[],
       end
     end
   end
-  
+
   return copy(dlSolversInfo)
 end
 
@@ -183,13 +183,13 @@ end
 
 """
   return all method-pointers for a solver.
-  
+
   tries to return all `method_ptr`s for all methods of a solver.
   This method checks if the `method_ptr`s are existent and different
-  from `C_NULL`. If not then this method tries to load the 
-  `dlname` ODE-Solver with the `loadODESolvers` method and checks again. 
+  from `C_NULL`. If not then this method tries to load the
+  `dlname` ODE-Solver with the `loadODESolvers` method and checks again.
   If even after this the `method_ptr`s are not found a exception is thrown.
-  
+
   see `loadODESolvers`.
   """
 function getAllMethodPtrs(dlname::AbstractString)

--- a/src/DLSolvers.jl
+++ b/src/DLSolvers.jl
@@ -95,38 +95,6 @@ function trytoloadmethod(libhandle::Ptr{Cvoid},method_name::AbstractString)
 end
 
 """
-  attemt to get the path of this module.
-
-  Returns path or nothing. May throw exceptions.
-  """
-function guess_path_of_module()
-  path_to_module = nothing
-  if path_to_module === nothing
-    path_sep = ""
-    if isdefined(Base, :path_separator)
-      path_sep = Base.path_separator
-    end
-    if isdefined(Base, :Filesystem) && 
-          isdefined(Base.Filesystem, :path_separator)
-      path_sep = Base.Filesystem.path_separator
-    end
-    path_to_module = Base.find_package("ODEInterface")
-    if path_to_module !== nothing
-      if endswith(path_to_module, ".jl")
-        path_to_module = path_to_module[1:end-3]
-      end
-      if endswith(path_to_module, "ODEInterface")
-        path_to_module = path_to_module[1:end-12]
-      end
-      if !endswith(path_to_module, path_sep)
-        path_to_module = string(path_to_module, path_sep)
-      end
-    end
-  end
-  return path_to_module
-end
-
-"""
        function loadODESolvers(extrapaths::Vector=AbstractString[],
                  loadlibnames::Tuple=() )
                 
@@ -161,14 +129,7 @@ end
 function loadODESolvers(extrapaths::Vector=AbstractString[],
           loadlibnames::Tuple=() )
   if isempty(extrapaths)
-    try
-      path_to_module = guess_path_of_module()
-      if path_to_module !== nothing
-        extrapaths = [ path_to_module ]
-      end
-    catch e
-      # At least we tried
-    end
+    extrapaths = [ @__DIR__ ]
   end
   for solver in solverInfo
     for variant in solver.variants

--- a/src/Deabm.jl
+++ b/src/Deabm.jl
@@ -53,7 +53,7 @@ mutable struct DdeabmInternalCallInfos{FInt<:FortranInt,
   loglevel     :: UInt64                # log level
   # RHS:
   N            :: FInt                  # Dimension of Problem
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   rhs_count    :: Int                   # count: number of calls to rhs
@@ -154,7 +154,7 @@ end
       ║                 │ The value will be rounded up to a        │         ║
       ║                 │ multiple of 500.                         │         ║
       ║                 │ OPT_MAXSTEPS > 0                         │         ║
-      ╚═════════════════╧══════════════════════════════════════════╧═════════╝ 
+      ╚═════════════════╧══════════════════════════════════════════╧═════════╝
 
   """
 function ddeabm(rhs, t0::Real, T::Real,
@@ -176,10 +176,10 @@ end
 const ddeabm_maxnum = 500
 
 """
-       function ddeabm_impl(rhs, 
-               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+       function ddeabm_impl(rhs,
+               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
                args::DdeabmArguments{FInt}) where FInt<:FortranInt
-  
+
   implementation of ddeabm-call for FInt.
 
   This solver has the conecpt of continuation calls (CC), see
@@ -203,11 +203,11 @@ const ddeabm_maxnum = 500
       ║ OUTPUTFCN_WODENSE │ given vector      │ no   INFO(3)=0     │  C3     ║
       ╠═══════════════════╪═══════════════════╧════════════════════╧═════════╣
       ║ OUTPUTFCN_DENSE   │        N O T    S U P P O R T E D !              ║
-      ╚═══════════════════╧══════════════════════════════════════════════════╝ 
+      ╚═══════════════════╧══════════════════════════════════════════════════╝
 
   """
-function ddeabm_impl(rhs, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function ddeabm_impl(rhs,
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::DdeabmArguments{FInt}) where FInt<:FortranInt
 
   (lio,l,l_g,l_solver,lprefix) = solver_start("ddeabm",rhs,t0,T,x0,opt)
@@ -266,7 +266,7 @@ function ddeabm_impl(rhs,
   args.INFO[3] = (case == 2) ? 1 : 0
   retcode = -100
 
-  cbi = DdeabmInternalCallInfos(lio, l, d, rhs, rhs_mode, rhs_lprefix, 
+  cbi = DdeabmInternalCallInfos(lio, l, d, rhs, rhs_mode, rhs_lprefix,
         0, output_mode, output_fcn, Dict())
 
   args.FCN = unsafe_SLATEC1RHSCallback_c(cbi, FInt(0))
@@ -285,7 +285,7 @@ function ddeabm_impl(rhs,
   end
 
   maxsteps_seen = 0
-  while (true) 
+  while (true)
     told = args.t[1]
     args.tEnd[1] = t_values[1]
     ccall( method_ddeabm, Cvoid,
@@ -377,13 +377,13 @@ end
   See `help_ddeabm_license` for the licsense information.
 
   ### Using `gfortran` and 64bit integers (Linux, Mac and Windows)
-  
+
   Here is an example how to compile DDEABM with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fPIC -fdefault-integer-8 
+       gfortran -c -fPIC -fdefault-integer-8
                 -fdefault-real-8 -fdefault-double-8 -o slatec.o slatec.f
-       gfortran -c -fPIC -fdefault-integer-8 
+       gfortran -c -fPIC -fdefault-integer-8
                 -fdefault-real-8 -fdefault-double-8 -o ddeabm.o ddeabm.f
 
   In order to get create a shared library (from the object file above) use
@@ -408,7 +408,7 @@ end
 push!(solverInfo,
   SolverInfo("ddeabm",
     "Adams-Bashforth-Moulton Predictor-Corrector method (orders: 1-12)",
-    tuple(:OPT_RTOL, :OPT_ATOL, :OPT_RHS_CALLMODE, 
+    tuple(:OPT_RTOL, :OPT_ATOL, :OPT_RHS_CALLMODE,
           :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_OUTPUTATTIMES,
           :OPT_TSTOP, :OPT_MAXSTEPS,

--- a/src/Debdf.jl
+++ b/src/Debdf.jl
@@ -57,7 +57,7 @@ mutable struct DdebdfInternalCallInfos{FInt<:FortranInt,
   loglevel     :: UInt64                # log level
   # RHS:
   N            :: FInt                  # Dimension of Problem
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   rhs_count    :: Int                   # count: number of calls to rhs
@@ -186,7 +186,7 @@ end
       ║                 │ the Jacobian matrix is banded and the    │         ║
       ║                 │ code is told this.                       │         ║
       ║                 │ see also help of BandedMatrix            │         ║
-      ╚═════════════════╧══════════════════════════════════════════╧═════════╝ 
+      ╚═════════════════╧══════════════════════════════════════════╧═════════╝
 
   """
 function ddebdf(rhs, t0::Real, T::Real,
@@ -208,10 +208,10 @@ end
 const ddebdf_maxnum = 500
 
 """
-       function ddebdf_impl(rhs, 
-               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+       function ddebdf_impl(rhs,
+               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
                args::DdebdfArguments{FInt}) where FInt<:FortranInt
-  
+
   implementation of ddebdf-call for FInt.
 
   This solver has the conecpt of continuation calls (CC), see
@@ -235,11 +235,11 @@ const ddebdf_maxnum = 500
       ║ OUTPUTFCN_WODENSE │ given vector      │ no   INFO(3)=0     │  C3     ║
       ╠═══════════════════╪═══════════════════╧════════════════════╧═════════╣
       ║ OUTPUTFCN_DENSE   │        N O T    S U P P O R T E D !              ║
-      ╚═══════════════════╧══════════════════════════════════════════════════╝ 
+      ╚═══════════════════╧══════════════════════════════════════════════════╝
 
   """
-function ddebdf_impl(rhs, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function ddebdf_impl(rhs,
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::DdebdfArguments{FInt}) where FInt<:FortranInt
 
   (lio,l,l_g,l_solver,lprefix) = solver_start("ddebdf",rhs,t0,T,x0,opt)
@@ -258,8 +258,8 @@ function ddebdf_impl(rhs,
   args.INFO = zeros(FInt, 15)
 
   # RWORK
-  args.LRW = [ FInt( 
-    jacobibandstruct === nothing ? 
+  args.LRW = [ FInt(
+    jacobibandstruct === nothing ?
       250+10*d+d*d : 250+10*d+(2*jacobibandstruct[1]+jacobibandstruct[2]+1)*d
     ) ]
   args.RWORK = zeros(Float64, args.LRW[1])
@@ -314,7 +314,7 @@ function ddebdf_impl(rhs,
   retcode = -100
 
   cbi = DdebdfInternalCallInfos(lio, l, d, rhs, rhs_mode, rhs_lprefix,
-        0, output_mode, output_fcn, Dict(), 
+        0, output_mode, output_fcn, Dict(),
         jacobimatrix === nothing ? dummy_func : jacobimatrix,
         jacobibandstruct, jac_lprefix, 0, get_view_function())
 
@@ -430,13 +430,13 @@ end
   See `help_ddebdf_license` for the licsense information.
 
   ### Using `gfortran` and 64bit integers (Linux, Mac and Windows)
-  
+
   Here is an example how to compile DDEBDF with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fPIC -fdefault-integer-8 
+       gfortran -c -fPIC -fdefault-integer-8
                 -fdefault-real-8 -fdefault-double-8 -o slatec.o slatec.f
-       gfortran -c -fPIC -fdefault-integer-8 
+       gfortran -c -fPIC -fdefault-integer-8
                 -fdefault-real-8 -fdefault-double-8 -o ddebdf.o ddbdfm.f
 
   In order to get create a shared library (from the object file above) use
@@ -460,7 +460,7 @@ end
 push!(solverInfo,
   SolverInfo("ddebdf",
     "Backward Differentiation Formula (orders: 1-5)",
-    tuple(:OPT_RTOL, :OPT_ATOL, :OPT_RHS_CALLMODE, 
+    tuple(:OPT_RTOL, :OPT_ATOL, :OPT_RHS_CALLMODE,
           :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_OUTPUTATTIMES,
           :OPT_TSTOP, :OPT_MAXSTEPS,

--- a/src/Dop853.jl
+++ b/src/Dop853.jl
@@ -40,7 +40,7 @@ end
        -2: larger OPT_MAXSTEPS is needed
        -3: step size becomes too small
        -4: problem is probably stiff (interrupted)
-  
+
   main call for using Fortran-dopri5 solver. In `opt` the following
   options are used:
 
@@ -94,8 +94,8 @@ end
       ║ INITIALSS       │ initial step size                        │     0.0 ║
       ║                 │ if OPT_INITIALSS == 0 then a initial     │         ║
       ║                 │ guess is computed                        │         ║
-      ╚═════════════════╧══════════════════════════════════════════╧═════════╝ 
-  
+      ╚═════════════════╧══════════════════════════════════════════╧═════════╝
+
   """
 function dop853(rhs, t0::Real, T::Real,
                 x0::Vector, opt::AbstractOptionsODE)
@@ -111,13 +111,13 @@ function dop853_i32(rhs, t0::Real, T::Real,
 end
 
 """
-       function dop853_impl(rhs, 
+       function dop853_impl(rhs,
                t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
                args::DopriArguments{FInt}) where {FInt<:FortranInt}
-  
+
   implementation of dop853 for FInt.
   """
-function dop853_impl(rhs, 
+function dop853_impl(rhs,
         t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::DopriArguments{FInt}) where {FInt<:FortranInt}
 
@@ -126,7 +126,7 @@ function dop853_impl(rhs,
   (method_dop853, method_contd8) = getAllMethodPtrs(
      (FInt == Int64) ? DL_DOP853 : DL_DOP853_I32 )
 
-  (d,nrdense,rhs_mode,output_mode,output_fcn) = 
+  (d,nrdense,rhs_mode,output_mode,output_fcn) =
     dopri_extract_commonOpt(t0,T,x0,opt,args)
 
   # WORK memory
@@ -176,7 +176,7 @@ function dop853_impl(rhs,
   out_lprefix = "unsafe_dopriSoloutCallback: "
   eval_lprefix = "eval_sol_fcn_closure: "
 
-  cbi = DopriInternalCallInfos(lio,l,rhs,rhs_mode,rhs_lprefix, 
+  cbi = DopriInternalCallInfos(lio,l,rhs,rhs_mode,rhs_lprefix,
       output_mode,output_fcn,
       Dict(), out_lprefix,eval_sol_fcn_noeval,eval_lprefix,
       NaN,NaN,Vector{Float64}(),
@@ -190,7 +190,7 @@ function dop853_impl(rhs,
   args.FCN = unsafe_HW1RHSCallback_c(cbi, FInt(0))
   args.SOLOUT = output_mode ≠ OUTPUTFCN_NEVER ?
      unsafe_dopriSoloutCallback_c(cbi, FInt(0)) :
-     @cfunction(dummy_func, Cvoid, () ) 
+     @cfunction(dummy_func, Cvoid, () )
   args.IPAR = cbi
 
   output_mode ≠ OUTPUTFCN_NEVER &&
@@ -212,9 +212,9 @@ function dop853_impl(rhs,
      Ptr{Float64}, Ref{DopriInternalCallInfos}, # RPAR, IPAR,
      Ptr{FInt},                                 #  IDID
     ),
-    args.N, args.FCN, 
+    args.N, args.FCN,
     args.t, args.x, args.tEnd,
-    args.RTOL, args.ATOL, args.ITOL, 
+    args.RTOL, args.ATOL, args.ITOL,
     args.SOLOUT, args.IOUT,
     args.WORK, args.LWORK,
     args.IWORK, args.LIWORK,
@@ -242,8 +242,8 @@ function dop853_impl(rhs,
 
 end
 
-"""  
-  ## Compile DOP853 
+"""
+  ## Compile DOP853
 
   The julia ODEInterface tries to compile and link the solvers
   automatically at the build-time of this module. The following
@@ -251,67 +251,67 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_dop853_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile DOP853 with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dop853.o dop853.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
+
        gfortran -shared -fPIC -o dop853.so dop853.o
        gfortran -shared -fPIC -o dop853.dylib dop853.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile DOP853 with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dop853.o dop853.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
+
        gfortran -shared -o dop853.dll dop853.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile DOP853 with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC  
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC
+                -fdefault-real-8 -fdefault-double-8
                 -o dop853_i32.o   dop853.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
        gfortran -shared -fPIC -o dop853_i32.so dop853_i32.o
        gfortran -shared -fPIC -o dop853_i32.dylib dop853_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile DOP853 with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
+
        gfortran -c
-                -fdefault-real-8 -fdefault-double-8 
+                -fdefault-real-8 -fdefault-double-8
                 -o dop853_i32.o   dop853.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o dop853_i32.dll dop853_i32.o
-  
+
   """
 function help_dop853_compile()
   return Docs.doc(help_dop853_compile)
@@ -327,10 +327,10 @@ end
 push!(solverInfo,
   SolverInfo("dop853",
     "Runge-Kutta method of order 8(5,3) due to Dormand & Prince",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
-          :OPT_MAXSTEPS, :OPT_STEST, :OPT_EPS, :OPT_RHO, 
-          :OPT_SSMINSEL, :OPT_SSMAXSEL, :OPT_SSBETA, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
+          :OPT_MAXSTEPS, :OPT_STEST, :OPT_EPS, :OPT_RHO,
+          :OPT_SSMINSEL, :OPT_SSMAXSEL, :OPT_SSBETA,
           :OPT_MAXSS, :OPT_INITIALSS),
     tuple(
       SolverVariant("dop853_i64",

--- a/src/Dopri5.jl
+++ b/src/Dopri5.jl
@@ -31,7 +31,7 @@ end
       function dopri5(rhs, t0::Real, T::Real,
                       x0::Vector, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
-  
+
   `retcode` can have the following values:
 
         1: computation successful
@@ -40,7 +40,7 @@ end
        -2: larger OPT_MAXSTEPS is needed
        -3: step size becomes too small
        -4: problem is probably stiff (interrupted)
-  
+
   main call for using Fortran-dopri5 solver. In `opt` the following
   options are used:
 
@@ -94,8 +94,8 @@ end
       ║ INITIALSS       │ initial step size                        │     0.0 ║
       ║                 │ if OPT_INITIALSS == 0 then a initial     │         ║
       ║                 │ guess is computed                        │         ║
-      ╚═════════════════╧══════════════════════════════════════════╧═════════╝ 
-  
+      ╚═════════════════╧══════════════════════════════════════════╧═════════╝
+
   """
 function dopri5(rhs, t0::Real, T::Real,
                 x0::Vector, opt::AbstractOptionsODE)
@@ -111,22 +111,22 @@ function dopri5_i32(rhs, t0::Real, T::Real,
 end
 
 """
-       function dopri5_impl(rhs, 
-               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+       function dopri5_impl(rhs,
+               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
                args::DopriArguments{FInt}) where FInt<:FortranInt
-  
+
   implementation of dopri5 for FInt.
   """
-function dopri5_impl(rhs, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function dopri5_impl(rhs,
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::DopriArguments{FInt}) where FInt<:FortranInt
-  
+
   (lio,l,l_g,l_solver,lprefix) = solver_start("dopri5",rhs,t0,T,x0,opt)
 
   (method_dopri5,method_contd5) = getAllMethodPtrs(
      (FInt == Int64) ? DL_DOPRI5 : DL_DOPRI5_I32 )
 
-  (d,nrdense,rhs_mode,output_mode,output_fcn) = 
+  (d,nrdense,rhs_mode,output_mode,output_fcn) =
     dopri_extract_commonOpt(t0,T,x0,opt,args)
 
   # WORK memory
@@ -209,12 +209,12 @@ function dopri5_impl(rhs,
      Ptr{Cvoid}, Ptr{FInt},                     # Soloutfunc, IOUT
      Ptr{Float64}, Ptr{FInt},                   # WORK, LWORK
      Ptr{FInt}, Ptr{FInt},                      # IWORK, LIWORK
-     Ptr{Float64}, Ref{DopriInternalCallInfos}, # RPAR, IPAR, 
+     Ptr{Float64}, Ref{DopriInternalCallInfos}, # RPAR, IPAR,
      Ptr{FInt},                                 # IDID
     ),
-    args.N, args.FCN, 
+    args.N, args.FCN,
     args.t, args.x, args.tEnd,
-    args.RTOL, args.ATOL, args.ITOL, 
+    args.RTOL, args.ATOL, args.ITOL,
     args.SOLOUT, args.IOUT,
     args.WORK, args.LWORK,
     args.IWORK, args.LIWORK,
@@ -241,8 +241,8 @@ function dopri5_impl(rhs,
   return ( args.t[1], args.x, args.IDID[1], stats)
 end
 
-"""  
-  ## Compile DOPRI5 
+"""
+  ## Compile DOPRI5
 
   The julia ODEInterface tries to compile and link the solvers
   automatically at the build-time of this module. The following
@@ -250,67 +250,67 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_dopri5_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile DOPRI5 with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dopri5.o dopri5.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
+
        gfortran -shared -fPIC -o dopri5.so dopri5.o
        gfortran -shared -fPIC -o dopri5.dylib dopri5.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile DOPRI5 with `Float64` reals and
   `Int64` integers with `gfortran`:
 
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dopri5.o dopri5.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
+
        gfortran -shared -o dopri5.dll dopri5.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile DOPRI5 with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC  
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC
+                -fdefault-real-8 -fdefault-double-8
                 -o dopri5_i32.o   dopri5.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
        gfortran -shared -fPIC -o dopri5_i32.so dopri5_i32.o
        gfortran -shared -fPIC -o dopri5_i32.dylib dopri5_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile DOPRI5 with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
+
        gfortran -c
-                -fdefault-real-8 -fdefault-double-8 
+                -fdefault-real-8 -fdefault-double-8
                 -o dopri5_i32.o   dopri5.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o dopri5_i32.dll dopri5_i32.o
-  
+
   """
 function help_dopri5_compile()
   return Docs.doc(help_dopri5_compile)
@@ -326,10 +326,10 @@ end
 push!(solverInfo,
   SolverInfo("dopri5",
     "Runge-Kutta method of order 5(4) due to Dormand & Prince",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
-          :OPT_MAXSTEPS, :OPT_STEST, :OPT_EPS, :OPT_RHO, 
-          :OPT_SSMINSEL, :OPT_SSMAXSEL, :OPT_SSBETA, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
+          :OPT_MAXSTEPS, :OPT_STEST, :OPT_EPS, :OPT_RHO,
+          :OPT_SSMINSEL, :OPT_SSMAXSEL, :OPT_SSBETA,
           :OPT_MAXSS, :OPT_INITIALSS),
     tuple(
       SolverVariant("dopri5_i64",

--- a/src/Error.jl
+++ b/src/Error.jl
@@ -6,7 +6,7 @@ import Base: showerror
 macro import_exceptions()
   :(
     using ODEInterface: WrappedODEException, ArgumentErrorODE,
-                        OutputErrorODE, SolverODEnotLoaded, 
+                        OutputErrorODE, SolverODEnotLoaded,
                         FunctionCallNotSupported, FeatureNotSupported,
                         StateErrorODE,
                         InternalErrorODE
@@ -15,7 +15,7 @@ end
 
 """
   The ancestor for all wrapped exceptions in ODEInterface.
-  
+
   Required fields: msg, error
   """
 abstract type WrappedODEException <: Base.WrappedException end
@@ -30,7 +30,7 @@ end
 
 """
   This error indicates that one input argument is invalid.
-  
+
   This is a WrappedException: If the invalidity of the argument
   was detected by some error/exception then, this initial
   error/exception can be found in the `error` field.
@@ -47,7 +47,7 @@ end
 
 function showerror(io::IO,e::ArgumentErrorODE)
   println(io,e.msg)
-  e.argname !== nothing && println(io,string("in argument ",e.argname)) 
+  e.argname !== nothing && println(io,string("in argument ",e.argname))
   if e.error !== nothing
     println(io,"Wrapped exception:")
     showerror(io,e.error)
@@ -69,7 +69,7 @@ end
 
 function showerror(io::IO,e::OutputErrorODE)
   println(io,e.msg)
-  e.func !== nothing && println(io,string("function ",e.func)) 
+  e.func !== nothing && println(io,string("function ",e.func))
   if e.error !== nothing
     println(io,"Wrapped exception:")
     showerror(io,e.error)
@@ -102,7 +102,7 @@ function FunctionCallNotSupported(msg)
 end
 
 """
-  This error indicates that a requested feature is not supported or 
+  This error indicates that a requested feature is not supported or
   is not possible.
   """
 mutable struct FeatureNotSupported <: WrappedODEException
@@ -141,4 +141,3 @@ end
 
 
 # vim:syn=julia:cc=79:fdm=indent:
-

--- a/src/HWcommon.jl
+++ b/src/HWcommon.jl
@@ -29,38 +29,38 @@ end
 
 """
        function unsafe_HW1RHSCallback(
-               n_::Ptr{FInt}, t_::Ptr{Float64}, x_::Ptr{Float64}, 
-               f_::Ptr{Float64}, rpar_::Ptr{Float64}, 
+               n_::Ptr{FInt}, t_::Ptr{Float64}, x_::Ptr{Float64},
+               f_::Ptr{Float64}, rpar_::Ptr{Float64},
                cbi::CI) where {FInt<:FortranInt, CI<:ODEinternalCallInfos}
                 -> nothing
-  
+
   This is the right-hand side given as callback to several Fortran-solvers,
   e.g. dopri5, dop853, odex.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_HW1RHSCallback(
-        n_::Ptr{FInt}, t_::Ptr{Float64}, x_::Ptr{Float64}, 
-        f_::Ptr{Float64}, rpar_::Ptr{Float64}, 
+        n_::Ptr{FInt}, t_::Ptr{Float64}, x_::Ptr{Float64},
+        f_::Ptr{Float64}, rpar_::Ptr{Float64},
         cbi::CI) where {FInt<:FortranInt, CI<:ODEinternalCallInfos}
 
   n = unsafe_load(n_); t = unsafe_load(t_)
   x = unsafe_wrap(Array, x_, (n,), own=false)
   f = unsafe_wrap(Array, f_, (n,), own=false)
-  
+
   hw1rhs(n,t,x,f,cbi)
   return nothing
 end
 
 """
-       function unsafe_HW1RHSCallback_c(cbi::CI, 
+       function unsafe_HW1RHSCallback_c(cbi::CI,
                fint_flag::FInt) where {FInt,CI}
           -> C-callable function pointer
 
   This method generates a Pointer to C-callable instructions.
   The two method type parameters `FInt` and `CI` are important:
-  `FInt` is the used Fortran integer type and `CI` is the used 
+  `FInt` is the used Fortran integer type and `CI` is the used
   `ODEinternalCallInfos` *SubType*.
   Because `unsafe_HW1RHSCallback` is a parameterized method,
   special variants are compiled, if `FInt` or `CI` changes.
@@ -69,7 +69,7 @@ end
   calls to such Julia-functions can be resolved at compile-time
   (instead of dynamic calls during run-time).
   """
-function unsafe_HW1RHSCallback_c(cbi::CI, 
+function unsafe_HW1RHSCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt,CI}
   return @cfunction(unsafe_HW1RHSCallback, Cvoid, (Ptr{FInt},Ptr{Float64},
     Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ref{CI}))
@@ -77,21 +77,21 @@ end
 
 """
        function unsafe_HW2RHSCallback(
-               n_::Ptr{FInt}, t_::Ptr{Float64}, x_::Ptr{Float64}, 
-               f_::Ptr{Float64}, rpar_::Ptr{Float64}, 
+               n_::Ptr{FInt}, t_::Ptr{Float64}, x_::Ptr{Float64},
+               f_::Ptr{Float64}, rpar_::Ptr{Float64},
                cbi::CI) where {FInt<:FortranInt, CI<:ODEinternalCallInfos}
                 -> nothing
-  
+
   This is the right-hand side given as callback to Fortran-solvers
-  (e.g. radau5 and radau) that can handle problems with "special structure", 
+  (e.g. radau5 and radau) that can handle problems with "special structure",
   see `help_specialstructure`.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_HW2RHSCallback(
-        n_::Ptr{FInt}, t_::Ptr{Float64}, x_::Ptr{Float64}, 
-        f_::Ptr{Float64}, rpar_::Ptr{Float64}, 
+        n_::Ptr{FInt}, t_::Ptr{Float64}, x_::Ptr{Float64},
+        f_::Ptr{Float64}, rpar_::Ptr{Float64},
         cbi::CI) where {FInt<:FortranInt, CI<:ODEinternalCallInfos}
 
   n = unsafe_load(n_); t = unsafe_load(t_)
@@ -139,25 +139,25 @@ end
 function unsafe_HW2RHSCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt,CI}
   return @cfunction(unsafe_HW2RHSCallback, Cvoid, (Ptr{FInt},Ptr{Float64},
-    Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ref{CI})) 
+    Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ref{CI}))
 end
 
 """
-       function unsafe_HW1MassCallback(n_::Ptr{FInt}, am_::Ptr{Float64}, 
-               lmas_::Ptr{FInt}, rpar_::Ptr{Float64}, 
+       function unsafe_HW1MassCallback(n_::Ptr{FInt}, am_::Ptr{Float64},
+               lmas_::Ptr{FInt}, rpar_::Ptr{Float64},
                cbi::CI) where {FInt<:FortranInt,CI<:ODEinternalCallInfos}
                 -> nothing
-  
+
   This is the MAS callback given to radau5, radau and seulex.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
-  
-  This function takes the values of  the mass matrix saved in 
+
+  This function takes the values of  the mass matrix saved in
   the InternalCallInfos.
   """
-function unsafe_HW1MassCallback(n_::Ptr{FInt}, am_::Ptr{Float64}, 
-        lmas_::Ptr{FInt}, rpar_::Ptr{Float64}, 
+function unsafe_HW1MassCallback(n_::Ptr{FInt}, am_::Ptr{Float64},
+        lmas_::Ptr{FInt}, rpar_::Ptr{Float64},
         cbi::CI) where {FInt<:FortranInt,CI<:ODEinternalCallInfos}
   n = unsafe_load(n_)
   lmas = unsafe_load(lmas_)
@@ -166,7 +166,7 @@ function unsafe_HW1MassCallback(n_::Ptr{FInt}, am_::Ptr{Float64},
 
   (lio,l)=(cbi.logio,cbi.loglevel)
   l_mas = l & LOG_MASS>0
-  
+
   l_mas && println(lio,lprefix,"called with n=",n," lmas=",lmas)
 
   mas = cbi.massmatrix
@@ -180,17 +180,17 @@ function unsafe_HW1MassCallback(n_::Ptr{FInt}, am_::Ptr{Float64},
     @assert (lmas,n) == size(mas)
     am[:] = mas
   end
-  
+
   l_mas && println(lio,lprefix,"am=",am)
   return nothing
 end
 
 """
-       function unsafe_HW1MassCallback_c(cbi::CI, 
+       function unsafe_HW1MassCallback_c(cbi::CI,
                fint_flag::FInt) where {FInt,CI}
           -> C-callable function pointer
   """
-function unsafe_HW1MassCallback_c(cbi::CI, 
+function unsafe_HW1MassCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt,CI}
  return @cfunction(unsafe_HW1MassCallback, Cvoid, (Ptr{FInt},
     Ptr{Float64}, Ptr{FInt}, Ptr{Float64}, Ref{CI}))
@@ -226,15 +226,15 @@ function extractSpecialStructureOpt(
 end
 
 """
-       function extractMassMatrix(M1::FInt, M2::FInt, 
+       function extractMassMatrix(M1::FInt, M2::FInt,
                NM1::FInt, args::AbstractArgumentsODESolver{FInt},
                opt::AbstractOptionsODE) where FInt<:FortranInt
-  
+
   extracts mass matrix and fills `IMAS`, `MLMAS` und `MUMAS` in args.
 
   reads options: `OPT_MASSMATRIX`
   """
-function extractMassMatrix(M1::FInt, M2::FInt, 
+function extractMassMatrix(M1::FInt, M2::FInt,
         NM1::FInt, args::AbstractArgumentsODESolver{FInt},
         opt::AbstractOptionsODE) where FInt<:FortranInt
   OPT = nothing
@@ -248,7 +248,7 @@ function extractMassMatrix(M1::FInt, M2::FInt,
       @assert 2==ndims(massmatrix)
       @assert (NM1,NM1,) == size(massmatrix)
       massmatrix = deepcopy(massmatrix)
-      args.IMAS = [1]; 
+      args.IMAS = [1];
       # A BandedMatrix with lower bandwidth == NM1 is treated as full!
       if isa(massmatrix,BandedMatrix) && massmatrix.l == NM1
         massmatrix=full(massmatrix)
@@ -271,21 +271,21 @@ end
 """
        function unsafe_HW1JacCallback(n_::Ptr{FInt},
                t_::Ptr{Float64},x_::Ptr{Float64},dfx_::Ptr{Float64},
-               ldfx_::Ptr{FInt}, rpar_::Ptr{Float64}, 
+               ldfx_::Ptr{FInt}, rpar_::Ptr{Float64},
                cbi::CI) where {FInt<:FortranInt, CI<:ODEinternalCallInfos}
                 -> nothing
-  
+
   This is the JAC callback given to radau5, radau and seulex.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
-  
+
   This function calls the user-given Julia function cbi.jacobimatrix
   with the appropriate arguments (depending on M1 and jacobibandstruct).
   """
 function unsafe_HW1JacCallback(n_::Ptr{FInt},
         t_::Ptr{Float64},x_::Ptr{Float64},dfx_::Ptr{Float64},
-        ldfx_::Ptr{FInt}, rpar_::Ptr{Float64}, 
+        ldfx_::Ptr{FInt}, rpar_::Ptr{Float64},
         cbi::CI) where {FInt<:FortranInt, CI<:ODEinternalCallInfos}
   n = unsafe_load(n_)
   t = unsafe_load(t_)
@@ -295,7 +295,7 @@ function unsafe_HW1JacCallback(n_::Ptr{FInt},
   lprefix = cbi.jac_lprefix
   (lio,l)=(cbi.logio,cbi.loglevel)
   l_jac = l & LOG_JAC>0
-  
+
   l_jac && println(lio,lprefix,"called with n=",n," ldfx=",ldfx)
   jac = cbi.jacobimatrix
   jb = cbi.jacobibandstruct
@@ -320,20 +320,20 @@ function unsafe_HW1JacCallback(n_::Ptr{FInt},
       jac(t,x,J...)
     end
   end
-  
+
   l_jac && println(lio,lprefix,"dfx=",M)
   return nothing
 end
 
 """
-       function unsafe_HW1JacCallback_c(cbi::CI, 
+       function unsafe_HW1JacCallback_c(cbi::CI,
                fint_flag::FInt) where {FInt,CI}
           -> C-callable function pointer
   """
-function unsafe_HW1JacCallback_c(cbi::CI, 
+function unsafe_HW1JacCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt,CI}
  return @cfunction(unsafe_HW1JacCallback, Cvoid, (Ptr{FInt},
-    Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, 
+    Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
     Ptr{FInt}, Ptr{Float64}, Ref{CI}))
 end
 
@@ -344,12 +344,12 @@ end
                dfdt_::Ptr{Float64}, rpar_::Ptr{Float64},
                cbi::CI) where {FInt<:FortranInt, CI<:ODEinternalCallInfos}
                 -> nothing
-  
+
   This is the DFX callback given to rodas.
 
-  The `unsafe` prefix in the name indicates that no validations are 
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
-  
+
   This function calls the user-given Julia function cbi.rhstimederiv
   with the appropriate arguments.
   """
@@ -374,11 +374,11 @@ function unsafe_HWRhsTimeDerivCallback(
 end
 
 """
-       function unsafe_HWRhsTimeDerivCallback_c(cbi::CI, 
+       function unsafe_HWRhsTimeDerivCallback_c(cbi::CI,
                fint_flag::FInt) where {FInt,CI}
           -> C-callable function pointer
   """
-function unsafe_HWRhsTimeDerivCallback_c(cbi::CI, 
+function unsafe_HWRhsTimeDerivCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt,CI}
   return  @cfunction(unsafe_HWRhsTimeDerivCallback, Cvoid, (Ptr{FInt},
     Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ref{CI}))
@@ -387,9 +387,9 @@ end
 """
        function extractJacobiOpt(d::FInt,
                M1::FInt,M2::FInt, NM1::FInt,
-               args::AbstractArgumentsODESolver{FInt}, 
+               args::AbstractArgumentsODESolver{FInt},
                opt::AbstractOptionsODE) where FInt<:FortranInt
-  
+
   extracts jacobi options and
   fills `IJAC`, `MLJAC` and `MUJAC` in args.
 
@@ -397,7 +397,7 @@ end
   """
 function extractJacobiOpt(d::FInt,
         M1::FInt,M2::FInt, NM1::FInt,
-        args::AbstractArgumentsODESolver{FInt}, 
+        args::AbstractArgumentsODESolver{FInt},
         opt::AbstractOptionsODE) where FInt<:FortranInt
   OPT = nothing
   jacobimatrix = nothing
@@ -406,13 +406,13 @@ function extractJacobiOpt(d::FInt,
     OPT = OPT_JACOBIMATRIX
     jacobimatrix = getOption(opt,OPT,nothing)
     # @assert (jacobimatrix === nothing) || isa(jacobimatrix,Function)
-    
+
     OPT = OPT_JACOBIBANDSTRUCT
     bs = getOption(opt, OPT, nothing)
-    
+
     if bs !== nothing
       jacobibandstruct = ( convert(FInt,bs[1]), convert(FInt,bs[2]) )
-      if jacobibandstruct[1] == NM1 
+      if jacobibandstruct[1] == NM1
         # A BandedMatrix with lower bandwidth == NM1 is treated as full!
         jacobibandstruct = nothing
       end
@@ -427,7 +427,7 @@ function extractJacobiOpt(d::FInt,
     throw(ArgumentErrorODE("Option '$OPT': Not valid", :opt, e))
   end
 
-  args.IJAC = [ jacobimatrix === nothing ? 0 : 1] 
+  args.IJAC = [ jacobimatrix === nothing ? 0 : 1]
   args.MLJAC = [ jacobibandstruct === nothing ? d : jacobibandstruct[1]  ];
   args.MUJAC=[ jacobibandstruct === nothing ? d : jacobibandstruct[2] ]
   jac_lprefix = "unsafe_HW1JacCallback: "
@@ -436,15 +436,15 @@ end
 
 """
        function extractRhsTimeDerivOpt(
-               args::AbstractArgumentsODESolver{FInt}, 
+               args::AbstractArgumentsODESolver{FInt},
                opt::AbstractOptionsODE) where FInt<:FortranInt
-  
-  extracts options for callback function for time-derivatives 
+
+  extracts options for callback function for time-derivatives
   of the right-hand-side and
   fills `IDFX` in args.
   """
 function extractRhsTimeDerivOpt(
-        args::AbstractArgumentsODESolver{FInt}, 
+        args::AbstractArgumentsODESolver{FInt},
         opt::AbstractOptionsODE) where FInt<:FortranInt
   OPT = OPT_RHSTIMEDERIV
   rhstimederiv = nothing
@@ -462,34 +462,34 @@ end
 
 """
   ## License
-  
+
   This is the license text, which can also be found at
-  
+
        http://www.unige.ch/~hairer/prog/licence.txt
-  
+
   Copyright (c) 2004, Ernst Hairer
-  
+
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are
   met:
-  
-  - Redistributions of source code must retain the above copyright 
+
+  - Redistributions of source code must retain the above copyright
   notice, this list of conditions and the following disclaimer.
-  
-  - Redistributions in binary form must reproduce the above copyright 
-  notice, this list of conditions and the following disclaimer in the 
+
+  - Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
   documentation and/or other materials provided with the distribution.
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS 
-  IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
-  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR 
-  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
-  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS
+  IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   """
 const hw_license = nothing

--- a/src/Help.jl
+++ b/src/Help.jl
@@ -3,8 +3,8 @@
 """macro for importing all the help-functions."""
 macro import_help()
   quote
-    using ODEInterface: help_overview, help_callsolvers, help_options, 
-          help_outputfcn, help_solversupport, help_install, 
+    using ODEInterface: help_overview, help_callsolvers, help_options,
+          help_outputfcn, help_solversupport, help_install,
           help_loadsolvers, help_specialstructure,
           help_internals
     @ODEInterface.import_dopri5_help
@@ -31,19 +31,19 @@ end
   # Overview
 
   ## Importing all help topics
-  
+
   You can use
-  
+
        using ODEInterface
        @ODEInterface.import_help
-  
+
   to have all `help_...` commands imported; so you can use
-  
+
        ?help_overview
        help_overview()
-  
+
   ## Help topics
-  
+
        help_install          requirements, installation, compiling the solvers
        help_solversupport    supported ODE solvers
        help_loadsolvers      loading the ODE solvers
@@ -51,11 +51,11 @@ end
        help_options          how to use parameters/options for solvers
        help_outputfcn        how to use "output functions", dense output
        help_specialstructure support for problems with "special structure"
-       
+
        help_internals        some internal/developer information
-  
+
   ## Help for each solver
-  
+
   Each solver has its own help page. Just look at the documentation of
   `dopri5`, `dop853`, `odex`, `radau5`, `radau`, `rodas`, `seulex`,
   `bvpsol`, `ddeabm` and `Bvpm2`.
@@ -66,7 +66,7 @@ end
 
 """
        function help_solversupport()
-  
+
   This function (when called) produces a (markdown) object with
   informations about the supported solvers.
   """
@@ -108,15 +108,15 @@ function help_solversupport()
         v = dlSolversInfo[variant.libname]
         @assert v.error === nothing
         @assert v.libhandle ≠ C_NULL
-      catch 
+      catch
         loaded = false
       end
-      
+
       first[2] = first[3] = true
       for method in variant.methods
         found = true
         try
-          index = findfirst( x -> x.generic_name == method, 
+          index = findfirst( x -> x.generic_name == method,
                              dlSolversInfo[variant.libname].methods )
           m = dlSolversInfo[variant.libname].methods[index]
           @assert m.error === nothing
@@ -147,14 +147,14 @@ end
 
 """
   ## Installation
-  
+
   Because this module is an *interface* for C-/Fortran-ODE-solvers, you
   need to compile/link the solvers before you can use them.
-  
+
   All solvers are dynamically loaded (at julia runtime),
   see `loadODESolvers`. Therefor a shared library is needed for every
   solver, i.e. you have to compile each solver and create a shared library.
-  
+
   See `help_solversupport` for a list with supported solvers and for
   further informations how to compile/link the solvers.
 
@@ -167,10 +167,10 @@ end
 
 """
   ## Loading the solvers
-  
-  All ODE solvers are dynamically loaded. See `help_install` for 
+
+  All ODE solvers are dynamically loaded. See `help_install` for
   informations how to create such shared libraries for the solvers.
-  
+
   Before using a solver for the 1st time, it has to be loaded by
   a call of `loadODESolvers`.
   """
@@ -180,69 +180,69 @@ end
 
 """
   ## Calling the Solvers
-  
+
   There are two ways of calling the solvers.
-  
+
   1. A calling convention close to the original Fortran-call,
      trying to provide/expose all the features the Fortran-codes have.
   1. A simplified version, closer to odecalls like in MATLAB.
-  
+
   ### The full-featured calling-method
-  
+
   All ODE-solvers have the same calling convention:
-  
-      (t,x,retcode,stats) = 
+
+      (t,x,retcode,stats) =
           odesolver(rhs, t0::Real, T::Real,
                     x0::Vector, opt::AbstractOptionsODErhs)
-  
+
       function rhs(t::Float64,x::Vector{Float64}) -> Vector{Float64}
           if OPT_RHS_CALLMODE == RHS_CALL_RETURNS_ARRAY
-  
-      function rhs(t::Float64,x::Vector{Float64},dx::Vector{Float64}) 
+
+      function rhs(t::Float64,x::Vector{Float64},dx::Vector{Float64})
           if OPT_RHS_CALLMODE == RHS_CALL_INSITU
-  
+
   The input arguments are:
-  
+
   1. a julia function `rhs` for evaluating the right-hand side of the ODE,
      see below.
      It's OK to return something, that `convert` can transform
      to a `Vector{Float64}`.
-  1. the initial time `t0`. `(t0,x0)` is the initial value of the 
+  1. the initial time `t0`. `(t0,x0)` is the initial value of the
      initial value problem.
   1. the final time `T`.
-  1. the initial state `x0`. `(t0,x0)` is the initial value of the 
+  1. the initial state `x0`. `(t0,x0)` is the initial value of the
      initial value problem.
-  1. further parameters/options in `opt` for the solver and for the interface. 
+  1. further parameters/options in `opt` for the solver and for the interface.
      There is a separate section for the explanation of the options, see
      help_options.
-  
+
   The output arguments are:
-  
-  1. `t` the *last* time for which the solution has been computed 
+
+  1. `t` the *last* time for which the solution has been computed
      (if the whole computation was successfull, then `t==T`)
   1. `x` the numerical solation at time `t`
   1. `retcode` the return code of the solver (interpretation is solver dependent)
-  
+
   There are two possible ways to provide the Julia right-hand side:
-  
+
       function rhs(t::Float64,x::Vector{Float64}) -> Vector{Float64}
-  
+
   This is used, if `OPT_RHS_CALLMODE == RHS_CALL_RETURNS_ARRAY`. So you can
   use anonymous functions like `(t,x) -> x` as right-hand sides. But this
   form has a price: every time the right-hand side is called, a temporary
   Array is created (the result). The form
-  
-      function rhs(t::Float64,x::Vector{Float64},dx::Vector{Float64}) 
+
+      function rhs(t::Float64,x::Vector{Float64},dx::Vector{Float64})
                    -> nothing
-  
+
   used if `OPT_RHS_CALLMODE == RHS_CALL_INSITU` does not have this problem.
   But the right-hand side must be a function filling in the values of `x'`
   in `dx`.
-  
+
   ### The simplified version
-  
+
   There is a simplified calling convention (using the methods above) to
-  provide a method like odecalls in MATLAB, 
+  provide a method like odecalls in MATLAB,
   see `odecall`.
   """
 function help_callsolvers()
@@ -254,27 +254,27 @@ end
 
   All options are handled by `OptionsODE`. See `OptionsODE` how to
   query, set and change options.
-  
+
   There are the following classes of options.
-  
+
   1. Options for this ODEInterface (common for all solvers)
   1. Options for the ODE solvers
-  
+
   ### Options of this ODEInterface
-  
+
   * `OPT_RHS_CALLMODE`:
-    There are two possible ways to call the Julia right-hand side: 
+    There are two possible ways to call the Julia right-hand side:
     `RHS_CALL_RETURNS_ARRAY` and `RHS_CALL_INSITU`, see
     `help_callsolvers` for an explanation.
     difference.
   * `OPT_LOGIO`:
     This option sets the `IO` that is used for logging messages
   * `OPT_LOGLEVEL`:
-    This is a bitmask for activating different logging messages. 
+    This is a bitmask for activating different logging messages.
     The following bitmasks are available.
-  
+
            LOG_NOTHING     log nothing
-           LOG_GENERAL     log some general information, 
+           LOG_GENERAL     log some general information,
                            especially the main julia call of the solver
            LOG_RHS         log all calls of the right-hand side
            LOG_SOLVERARGS  log the arguments for the C-/Fortran-calls
@@ -291,13 +291,13 @@ end
            LOG_JACBC       log calls of the jacobian of the boundary condition
            LOG_GUESS       log calls to the guess function
            LOG_ALL         all of the above
-  
+
   ### Options for the solvers
-  
+
   Different solvers support different options. All the options a solver
   supports are listed in the help-command of the specific solver, e.g.
   `help_dopri5`.
-  
+
   To get an overview, what options are supported by what solvers,
   call `ODEInterface.help_options()`.
   """
@@ -337,7 +337,7 @@ function help_options()
 
   for opt in opts
     write(io,"      ║ ",rpad(opt,21))
-    for solver in solvers; 
+    for solver in solvers;
       write(io,"│ ",(solver ∈ opt_usage[opt]) ? "✔" : " ")
     end
     write(io,"║\n")
@@ -351,28 +351,28 @@ function help_options()
 end
 
 """
-  ## `OPT_OUTPUTMODE` 
-  
+  ## `OPT_OUTPUTMODE`
+
   This option determines if the `OPT_OUTPUTFCN` is
   called, and if dense output (the `eval_sol_fcn`) is prepared/supported.
-  
+
   * `OUTPUTFCN_NEVER`: don't call the output function
   * `OUTPUTFCN_WODENSE`: call the output function, but `eval_sol_fcn`
     is not used
   * `OUTPUTFCN_DENSE`: call the output function and prepare `eval_sol_fcn`
 
-  ## `OPT_OUTPUTFCN` 
-  
+  ## `OPT_OUTPUTFCN`
+
        function outputfcn(reason::OUTPUTFCN_CALL_REASON,
         told::Float64,t::Float64, x::Vector{Float64},eval_sol_fcn::Function,
         extra_data::Dict)  -> OUTPUTFCN_RETURN_VALUE
-  
-  A (julia) function that is called 
-  
+
+  A (julia) function that is called
+
   1. at beginning of the solution process with
      `reason == OUTPUTFCN_CALL_INIT`, `told=t0`, `t`=`T`, `x=x0`,
      `eval_sol_fcn` a dummy function throwing an error if called,
-     `extra_data` a `Dict` persistent until the last call of the output 
+     `extra_data` a `Dict` persistent until the last call of the output
      function. The return value is *ignored*.
   1. after every successfull integration step with
      `reason == OUTPUTFCN_CALL_STEP`, `[told,t]` the time interval of the
@@ -385,16 +385,16 @@ end
      The return value is *ignored*.
 
   With `eval_sol_fcn`
-  
+
           function eval_sol_fcn(t1::Float64) -> Vector{Float64}
-  
+
   the numerical solution can be evaluted in the
   time interval `[told,t]` (if `OPT_OUTPUTMODE == OUTPUTFCN_DENSE`).
-  
+
   If supported by the solver, the numerical solution may be changed
   in the `outputfcn` (if `reason == OUTPUTFCN_CALL_STEP`) and the solver
   continues the process with the changed solution.
-  The return value `OUTPUTFCN_RET_CONTINUE_XCHANGED` indicates 
+  The return value `OUTPUTFCN_RET_CONTINUE_XCHANGED` indicates
   this. `OUTPUTFCN_RET_CONTINUE` tells the solver to continue (without
   changes in `x`) and `OUTPUTFCN_RET_STOP` tells the solver to stop the
   solver.
@@ -405,28 +405,28 @@ end
 
 """
   ## Special Structure
-  
+
   Some solvers (e.g. radau5 and radau) supports ODEs with a
-  "special structure". In this context an ODE has special structure 
+  "special structure". In this context an ODE has special structure
   if there exists M1>0 and M2>0 and M1 = M⋅M2 for some integer M
   and
-  
+
                    x'(k) = x(k+M2)   for all k = 1,…,M1            (*)
-  
+
   There are the options `OPT_M1` and `OPT_M2` to tell the solvers, if the
   ODE has this special structure. In this case only the non-trivial parts
-  of the right-hand side, of the mass matrix and of the Jacobian matrix 
+  of the right-hand side, of the mass matrix and of the Jacobian matrix
   had to be supplied.
-  
-  If an ODE has the special structure, then the right-hand side 
+
+  If an ODE has the special structure, then the right-hand side
   for `OPT_RHS_CALLMODE == RHS_CALL_RETURNS_ARRAY` has to return
   a vector of length d-M1 because the right-hand side for the first M1 entries
   are known from (*). For `OPT_RHS_CALLMODE == RHS_CALL_INSITU` the
   right-hand side gets (a reference) to the array of length d, but only
   the last d-M1 components need to be filled in.
-  
+
   The mass matrix has the form
-  
+
            ⎛ 1    │    ⎞ ⎫
            ⎜  ⋱   │    ⎟ ⎪
            ⎜   ⋱  │    ⎟ ⎬ M1
@@ -436,11 +436,11 @@ end
            ⎜      │    ⎟ ⎫
            ⎜      │ M̃  ⎟ ⎬ d-M1
            ⎝      │    ⎠ ⎭
-  
+
   Then there has to be only the (d-M1)×(d-M1) matrix M̃ in `OPT_MASSMATRIX`.
   Of course, M̃ can be banded. Then `OPT_MASSMATRIX` is a `BandedMatrix` with
   lower bandwidth < d-M1.
-  
+
   If an ODE has the special structure, then the Jacobian matrix has the form
 
            ⎛0   1      ⎞ ⎫
@@ -452,26 +452,26 @@ end
            ⎜           ⎟ ⎫
            ⎜      J̃    ⎟ ⎬ d-M1
            ⎝           ⎠ ⎭
-  
+
   Then there has to be only the (d-M1)×d matrix J̃ in `OPT_JACOBIMATRIX`.
   In this case banded Jacobian matrices are only supported for the
   case M1 + M2 == d. Then in this case J̃ is divided into d/M2 = 1+(M1/M2)
   blocks of the size M2×M2. All this blocks can be banded with a (common)
-  lower bandwidth < M2. 
-  
+  lower bandwidth < M2.
+
   The option `OPT_JACOBIBANDSTRUCT` is used to describe the banded structure
   of the Jacobian. It is eigher `nothing` if the Jacobian is full or a
   tuple `(l,u)` with the lower and upper bandwidth.
-  
+
   The function for providing the Jacobian for ∂f/∂x can have the following
   forms:
-  
+
        function (t,x,J)       -> nothing       (A)
        function (t,x,J1,…,JK) -> nothing       (B)
-  
-  The following table shows when `OPT_JACOBIMATRIX` has the form (A) 
+
+  The following table shows when `OPT_JACOBIMATRIX` has the form (A)
   and when it has the form (B):
-  
+
        ╔══════╤═════════════════════════════╤════════════════════════════════╗
        ║      │ JACOBIBANDSTRUCT == nothing │ JACOBIBANDSTRUCT == (l,u)      ║
        ╟──────┼─────────────────────────────┼────────────────────────────────╢

--- a/src/ODEInterface.jl
+++ b/src/ODEInterface.jl
@@ -1,37 +1,37 @@
 """
   # ODEInterface
-  
-  This julia module provides an interface to solvers for 
+
+  This julia module provides an interface to solvers for
   ordinary differential equations (ODEs) written in Fortran
   for solving initial value problems of the form
-  
+
       x' = rhs(t,x),      x(t₀) = x₀
-  
+
   or (for solvers supporting a "mass matrix" M)
-  
+
       M⋅x' = rhs(t,x),    x(t₀) = x₀.
-  
+
   ## What does "Interface" mean?
-  
+
   This julia module does *not* contain code for solving initial value
   problems, but this module does contain code for interacting with
   compiled Fortran-solvers. That's the reason, why this module is not called
   ODESuite.
-  
+
   ## What solvers are currently supported?
-  
+
   Currently the following Fortran-solvers, written by
   Prof. E. Hairer and Prof. G. Wanner, are supported:
-  
+
   * dopri5: explicit Runge-Kutta method of order 5(4) due to Dormand & Prince
   * dop853: explicit Runge-Kutta method of order 8(5,3) due to Dormand & Prince
   * odex: GBS extrapolation-algorithm based on the explicit midpoint rule
   * radau5: implicit Runge-Kutta method (Radau IIA) of order 5
-  * radau: implicit Runge-Kutta method (Radau IIA) of variable order 
+  * radau: implicit Runge-Kutta method (Radau IIA) of variable order
     between 5 and 13
   * seulex: extrapolation-algorithm based on the linear implicit Euler method
   * rodas: Rosenbrock method of order 4(3) (with possibly singular mass matrix)
-  
+
   see [Software page of Prof. Hairer](http://www.unige.ch/~hairer/software.html).
 
   Additionally the following Fortran-solvers from the
@@ -40,9 +40,9 @@
 
   * ddeabm: Adams-Bashforth-Moulton Predictor-Corrector method (order between 1 and 12)
   * ddebdf: Backward Differentiation Formula (orders between 1 and 5)
-  
+
   The following features of this solvers are supported by this ODEInterface:
-  
+
   * providing an output function (e.g. for dense output or for event location)
     to the solvers
   * providing mass- and jacobi-matrices for the solvers (with support for
@@ -51,10 +51,10 @@
   * support for problems with "special structure", see `help_specialstructure`
 
   Also supported:
-  
+
   * bvpsol: a boundary value problem solver for highly nonlinear two point
     boundary value problems using either a local linear solver or a global
-    sparse linear solver. **Please note: The license for `bvpsol` only 
+    sparse linear solver. **Please note: The license for `bvpsol` only
     covers non commercial use, see [License](./LICENSE.md).**
     written by P. Deuflhard, G. Bader, L. Weimann, see
     [CodeLib at ZIB](http://elib.zib.de/pub/elib/codelib/en/bvpode.html).
@@ -66,9 +66,9 @@
     boundary value ordinary differential equations with defect and global error control.
     Written by J. J. Boisvert, P.H. Muir and R. J. Spiteri, see
     [BVP_M-2 Page](http://cs.stmarys.ca/~muir/BVP_SOLVER_Webpage.shtml).
-  
+
   ## What are the requirements for this module
-  
+
   In order to use this module, you have to *compile* the supported
   Fortran solvers and provide a shared library for each solver.
   The build-script of this module tries to compile all solvers
@@ -76,19 +76,19 @@
   different compile-time options or compilers). Just call
   `ODEInterface.help_solversupport` for further informations (help topics)
   on how to compile the solvers and how to create shared libraries.
-  
+
   ## Further help
-  
-  see `ODEInterface.help_overview` for an overview of some help topics. 
-  
+
+  see `ODEInterface.help_overview` for an overview of some help topics.
+
   ## Contacting the author of this module
-  
-  The author of this julia module is 
-  
+
+  The author of this julia module is
+
        Dr. Christian Ludwig
        email: ludwig@ma.tum.de
          (Faculty of Mathematics, Technische Universität München)
-  
+
   """
 module ODEInterface
 
@@ -166,10 +166,10 @@ end
 
 """
   Type describing a "variant" of a solver.
-  
+
   What is a variant of a solver? Some solvers support more than one
   forms of dynamic libraries, e.g. with 32bit integers and with 64bit
-  integers. The purpose of this type is to have enough fields for 
+  integers. The purpose of this type is to have enough fields for
   describing such an variant.
   """
 struct SolverVariant
@@ -194,7 +194,7 @@ end
 """
   In this array every (supported) solver appends its SolverInfo-record.
   """
-const solverInfo = Vector{SolverInfo}() 
+const solverInfo = Vector{SolverInfo}()
 
 
 """
@@ -214,23 +214,23 @@ abstract type AbstractODESolution{FInt} end
 macro import_OPTcommon()
   :(
     using ODEInterface:   OPT_LOGIO, OPT_LOGLEVEL, OPT_RHS_CALLMODE,
-                          OPT_RTOL, OPT_ATOL, OPT_MAXSTEPS, OPT_EPS, 
+                          OPT_RTOL, OPT_ATOL, OPT_MAXSTEPS, OPT_EPS,
                           OPT_METHODCHOICE,
                           OPT_OUTPUTFCN, OPT_OUTPUTMODE, OPT_OUTPUTATTIMES,
                           OPT_STEST, OPT_RHO, OPT_SSMINSEL,
                           OPT_SSMAXSEL, OPT_SSBETA, OPT_MAXSS, OPT_INITIALSS,
                           OPT_TSTOP,
-                          OPT_MAXEXCOLUMN, OPT_MAXSTABCHECKS, 
+                          OPT_MAXEXCOLUMN, OPT_MAXSTABCHECKS,
                           OPT_MAXSTABCHECKLINE, OPT_INTERPOLDEGREE,
-                          OPT_ORDERDECFRAC, OPT_ORDERINCFRAC, 
+                          OPT_ORDERDECFRAC, OPT_ORDERINCFRAC,
                           OPT_STEPSIZESEQUENCE,
                           OPT_SSREDUCTION, OPT_SSSELECTPAR1, OPT_SSSELECTPAR2,
-                          OPT_RHO2, OPT_DENSEOUTPUTWOEE, 
+                          OPT_RHO2, OPT_DENSEOUTPUTWOEE,
                           OPT_TRANSJTOH,
                           OPT_MAXNEWTONITER, OPT_NEWTONSTARTZERO,
                           OPT_DIMOFIND1VAR, OPT_DIMOFIND2VAR, OPT_DIMOFIND3VAR,
                           OPT_STEPSIZESTRATEGY, OPT_M1, OPT_M2,
-                          OPT_JACRECOMPFACTOR, OPT_NEWTONSTOPCRIT, 
+                          OPT_JACRECOMPFACTOR, OPT_NEWTONSTOPCRIT,
                           OPT_FREEZESSLEFT, OPT_FREEZESSRIGHT, OPT_MASSMATRIX,
                           OPT_JACOBIMATRIX, OPT_JACOBIBANDSTRUCT,
                           OPT_MAXSTAGES, OPT_MINSTAGES, OPT_INITSTAGES,
@@ -240,7 +240,7 @@ macro import_OPTcommon()
                           OPT_WORKFORRHS, OPT_WORKFORJAC, OPT_WORKFORDEC,
                           OPT_WORKFORSOL, OPT_RHSTIMEDERIV,
                           OPT_BVPCLASS, OPT_SOLMETHOD,
-                          OPT_IVPOPT, 
+                          OPT_IVPOPT,
                           OPT_COLLOCATIONPTS, OPT_SUBINTERVALS,
                           OPT_FREEZEINTERVALS, OPT_DIAGNOSTICOUTPUT,
                           OPT_ADDGRIDPOINTS, OPT_MAXSUBINTERVALS,
@@ -349,11 +349,11 @@ const OPT_SINGULARTERM     = "SingularTerm"
 
 @doc """
   The right-hand side has to return `x'` as Array.
-  
+
   The right-hand side must be a function of the form
-  
+
        funtion (t,x) -> dx
-  
+
   `dx` is a `Vector{Float64}` with the same length as `x`.
   """
 RHS_CALL_RETURNS_ARRAY
@@ -363,20 +363,20 @@ RHS_CALL_RETURNS_ARRAY
   where it has to save the the values of `x'`.
 
   The right-hand side must be a function of the form
-  
+
        funtion (t,x,dx) -> nothing
-  
+
   `dx` is a `Vector{Float64}` with the same length as `x`. In `dx` the
   function has to fill in the values of `x'`.
   """
 RHS_CALL_INSITU
 
 """
-       function extractTOLs(d::Integer, opt::AbstractOptionsODE) 
+       function extractTOLs(d::Integer, opt::AbstractOptionsODE)
               -> (scalarFlag,rtol,atol)
-  
+
   extract `OPT_RTOL` and `OPT_ATOL` and convert to `Vector{Float64}`.
-  
+
   Supports scalar `OPT_RTOL` and `OPT_ATOL` and converts them to a
   `Vector{Float64}` of length 1.
 
@@ -415,9 +415,9 @@ end
 
 """
        function extractLogOptions(opt::AbstractOptionsODE) -> (lio, lev)
-  
+
   Extract options for logging.
-  
+
   throws ArgumentErrorODE if logio is not an IO or
   if loglevel is not convertable to UInt64.
 
@@ -439,7 +439,7 @@ function extractLogOptions(opt::AbstractOptionsODE)
 end
 
 """
-       function extractOutputFcn(opt::AbstractOptionsODE) 
+       function extractOutputFcn(opt::AbstractOptionsODE)
               -> (output_mode, output_fcn)
 
   reads options: `OPT_OUTPUTMODE`, `OPT_OUTPUTFCN`
@@ -447,24 +447,24 @@ end
 function extractOutputFcn(opt::AbstractOptionsODE)
   OPT = nothing
   output_mode = OUTPUTFCN_NEVER; output_fcn = output_fcn_donothing
-  try 
+  try
     OPT = OPT_OUTPUTMODE; output_mode = getOption(opt,OPT,OUTPUTFCN_NEVER)
     @assert isa(output_mode,OUTPUTFCN_MODE)
-    
+
     if output_mode ≠ OUTPUTFCN_NEVER
-      OPT = OPT_OUTPUTFCN; 
+      OPT = OPT_OUTPUTFCN;
       output_fcn = getOption(opt,OPT,nothing)
       @assert isa(output_fcn,Function)
     end
   catch e
     throw(ArgumentErrorODE("Option '$OPT' invalid",:opt,e))
   end
-  
+
   return (output_mode,output_fcn)
 end
 
 """
-       function solver_init(solver_name::AbstractString, 
+       function solver_init(solver_name::AbstractString,
                             opt::AbstractOptionsODE)
           ->  (lio,l,l_g,l_solver,lprefix)
 
@@ -478,17 +478,17 @@ function solver_init(solver_name::AbstractString, opt::AbstractOptionsODE)
 end
 
 """
-       function solver_start(solver_name::AbstractString, rhs, 
+       function solver_start(solver_name::AbstractString, rhs,
                    t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE)
           ->  (lio,l,l_g,l_solver,lprefix)
-  
+
   initialization for a (typical) solver call/start.
 
   reads options: `OPT_LOGIO`, `OPT_LOGLEVEL`
   """
-function solver_start(solver_name::AbstractString, rhs, 
+function solver_start(solver_name::AbstractString, rhs,
             t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE)
-  
+
   (lio,l,l_g,l_solver,lprefix) = solver_init(solver_name,opt)
 
   if l_g
@@ -496,14 +496,14 @@ function solver_start(solver_name::AbstractString, rhs,
       "called with rhs=",rhs," t0=",t0," T=",T," x0=",x0," and opt")
     show(lio,opt); println(lio)
   end
-  
+
   return (lio,l,l_g,l_solver,lprefix)
 end
 
 """
        function solver_extract_rhsMode(opt::AbstractOptionsODE)
                    -> rhs_mode
-  
+
   reads options: `OPT_RHS_CALLMODE`
   """
 function solver_extract_rhsMode(opt::AbstractOptionsODE)
@@ -517,20 +517,20 @@ function solver_extract_rhsMode(opt::AbstractOptionsODE)
 end
 
 """
-       function solver_extract_commonOpt(t0::Real, T::Real, x0::Vector, 
-                    opt::AbstractOptionsODE, 
+       function solver_extract_commonOpt(t0::Real, T::Real, x0::Vector,
+                    opt::AbstractOptionsODE,
                     args::AbstractArgumentsODESolver{FInt}) where FInt
          -> (d,nrdense,scalarFlag,rhs_mode,output_mode,output_fcn)
 
   get d, fill args.N, args.x, args.t, args.tEnd, args.RTOL, args.ATOL
 
-  reads options: `OPT_RTOL`, `OPT_ATOL`, `OPT_RHS_CALLMODE`, 
+  reads options: `OPT_RTOL`, `OPT_ATOL`, `OPT_RHS_CALLMODE`,
   `OPT_OUTPUTMODE`, `OPT_OUTPUTFCN`
   """
-function solver_extract_commonOpt(t0::Real, T::Real, x0::Vector, 
-             opt::AbstractOptionsODE, 
+function solver_extract_commonOpt(t0::Real, T::Real, x0::Vector,
+             opt::AbstractOptionsODE,
              args::AbstractArgumentsODESolver{FInt}) where FInt
-  
+
   d = FInt(0)
   try
     d=convert(FInt,length(x0))
@@ -564,7 +564,7 @@ function solver_extract_commonOpt(t0::Real, T::Real, x0::Vector,
   if output_mode == OUTPUTFCN_NEVER
     nrdense = FInt(0);
   else
-    nrdense = d; 
+    nrdense = d;
   end
 
   return (d,nrdense,scalarFlag,rhs_mode,output_mode,output_fcn)

--- a/src/Options.jl
+++ b/src/Options.jl
@@ -7,22 +7,22 @@ using Dates
 """macro for importing OptionsODE and option handling."""
 macro import_options()
   :(
-    using ODEInterface: OptionsODE, getOption, setOption!, setOptions!, 
+    using ODEInterface: OptionsODE, getOption, setOption!, setOptions!,
                         copyOptions!
   )
 end
 
 """
   Ancestor for all types storing options for ODE-solvers.
-  
+
   ODE-solvers often have serveral parameters for fine-tuning them.
-  In this ODEInterface this parameters are called 'options' and 
-  they are stored in key/value paris. For the key a 
+  In this ODEInterface this parameters are called 'options' and
+  they are stored in key/value paris. For the key a
   `AbstractString` is used. The value can be `Any`-thing.
   The key is often called the option-name.
-  
+
   All types for this purpose have this abstract type as super-type.
-  
+
   Required fields are: `name`, `lastchanged`, `options`
   """
 abstract type AbstractOptionsODE end
@@ -30,24 +30,24 @@ abstract type AbstractOptionsODE end
 """
   Stores options for ODE-Solver(s) together with a name.
   Additionally the time of the last change is saved.
-  
+
   Options can be set at construction time, e.g.
-  
+
        opt=OptionsODE("test",
                       "loglevel" => ODEInterface.LOG_ALL,
                       "logio"    => stderr)
-  
-  or later. For changing single options 
-  
+
+  or later. For changing single options
+
        oldValue = setOption!(opt,"myopt","new value")
        oldValue = setOption!(opt,"myopt" => "new value")
-  
+
   and for changing many options at once:
-  
+
        oldValues = setOption!(opt,
                    "myopt" => "new value",
                    "oldopt" => 56)
-  
+
   see also: `setOption!`, `setOptions!`
   """
 mutable struct OptionsODE <: AbstractOptionsODE
@@ -61,13 +61,13 @@ mutable struct OptionsODE <: AbstractOptionsODE
   end
 end
 
-function OptionsODE(name::AbstractString,copyOptionsFrom::AbstractOptionsODE) 
+function OptionsODE(name::AbstractString,copyOptionsFrom::AbstractOptionsODE)
   opt = OptionsODE(name)
   copyOptions!(opt,copyOptionsFrom)
   return opt
 end
 
-function OptionsODE(copyOptionsFrom::AbstractOptionsODE) 
+function OptionsODE(copyOptionsFrom::AbstractOptionsODE)
   return OptionsODE("",copyOptionsFrom)
 end
 
@@ -85,7 +85,7 @@ end
      function getOption(opt::AbstractOptionsODE,name::AbstractString,
                         default::Any=nothing)
 
-  get saved value of option with given `name` or `default` 
+  get saved value of option with given `name` or `default`
   if option is unknown.
   """
 function getOption(opt::AbstractOptionsODE,name::AbstractString,
@@ -96,7 +96,7 @@ end
 """
      function setOption!(opt::AbstractOptionsODE,name::AbstractString,value::Any)
 
-  set ODE-Option with given `name` and return old value 
+  set ODE-Option with given `name` and return old value
   (or `nothing` if there was no old value).
   """
 function setOption!(opt::AbstractOptionsODE,name::AbstractString,value::Any)
@@ -109,7 +109,7 @@ end
 """
      function setOption!(opt::AbstractOptionsODE,pair::Pair)
 
-  set ODE-Option with given (`name`,`value`) pair and return old value 
+  set ODE-Option with given (`name`,`value`) pair and return old value
   (or `nothing` if there was no old value).
   """
 function setOption!(opt::AbstractOptionsODE,pair::Pair)
@@ -152,7 +152,7 @@ function show(io::IO, opt::AbstractOptionsODE)
       show(io,opt.options[key]); println(io)
     end
   end
-  print(io,"lasted changed "); show(io,opt.lastchanged); 
+  print(io,"lasted changed "); show(io,opt.lastchanged);
 end
 
 # vim:syn=julia:cc=79:fdm=indent:

--- a/src/Radau.jl
+++ b/src/Radau.jl
@@ -56,14 +56,14 @@ end
 
 """
   Type encapsulating all required data for Radau5/Radau-Solver-Callbacks.
-  
+
   We have the typical calling stack:
 
        radau5/radau
            call_julia_output_fcn(  ... INIT ... )
                output_fcn ( ... INIT ...)
            ccall( RADAU5_/RADAU_ ... )
-               unsafe_HW1MassCallback  
+               unsafe_HW1MassCallback
               ┌───────────────────────────────────────────┐  ⎫
               │unsafe_HW2RHSCallback                      │  ⎬ cb. rhs
               │    rhs                                    │  ⎪
@@ -82,7 +82,7 @@ end
            call_julia_output_fcn(  ... DONE ... )
                output_fcn ( ... DONE ...)
   """
-mutable struct RadauInternalCallInfos{FInt<:FortranInt, RHS_F, 
+mutable struct RadauInternalCallInfos{FInt<:FortranInt, RHS_F,
         OUT_F, JAC_F} <: ODEinternalCallInfos
   logio        :: IO                    # where to log
   loglevel     :: UInt64                # log level
@@ -90,7 +90,7 @@ mutable struct RadauInternalCallInfos{FInt<:FortranInt, RHS_F,
   M1           :: FInt
   M2           :: FInt
   # RHS:
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   # SOLOUT & output function
@@ -98,7 +98,7 @@ mutable struct RadauInternalCallInfos{FInt<:FortranInt, RHS_F,
   output_fcn   :: OUT_F                 # the output function to call
   output_data  :: Dict                  # extra_data for output_fcn
   out_lprefix  :: AbstractString        # saved log-prefix for solout
-  eval_sol_fcn :: Function              # eval_sol_fcn 
+  eval_sol_fcn :: Function              # eval_sol_fcn
   eval_lprefix :: AbstractString        # saved log-prefix for eval_sol
   tOld         :: Float64               # tOld and
   tNew         :: Float64               # tNew and
@@ -116,11 +116,11 @@ mutable struct RadauInternalCallInfos{FInt<:FortranInt, RHS_F,
 end
 
 """
-       type RadauArguments{FInt<:FortranInt} <: 
+       type RadauArguments{FInt<:FortranInt} <:
                 AbstractArgumentsODESolver{FInt}
-  
+
   Stores Arguments for Radau5 and Radau solver.
-  
+
   FInt is the Integer type used for the fortran compilation.
   """
 mutable struct RadauArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
@@ -159,35 +159,35 @@ end
 
 """
        function unsafe_radauSoloutCallback(
-               nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-               x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-               n_::Ptr{FInt}, rpar_::Ptr{Float64}, 
+               nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+               x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt},
+               n_::Ptr{FInt}, rpar_::Ptr{Float64},
                cbi::CI, irtrn_::Ptr{FInt}) where {FInt<:FortranInt,
                                                   CI<:RadauInternalCallInfos}
-  
+
   This is the solout given as callback to Fortran radau5/radau.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
 
   This function saves the state informations of the solver in
   `RadauInternalCallInfos`, where they can be found by
   the `eval_sol_fcn`, see `create_radau_eval_sol_fcn_closure`.
-  
+
   Then the user-supplied `output_fcn` is called (which in turn can use
   `eval_sol_fcn`, to evalutate the solution at intermediate points).
-  
+
   The return value of the `output_fcn` is propagated to `RADAU5_`/`RADAU_`.
-  
+
   For the typical calling sequence, see `RadauInternalCallInfos`.
   """
 function unsafe_radauSoloutCallback(
-        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-        x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-        n_::Ptr{FInt}, rpar_::Ptr{Float64}, 
+        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+        x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt},
+        n_::Ptr{FInt}, rpar_::Ptr{Float64},
         cbi::CI, irtrn_::Ptr{FInt}) where {FInt<:FortranInt,
                                            CI<:RadauInternalCallInfos}
-  
+
   nr = unsafe_load(nr_); told = unsafe_load(told_); t = unsafe_load(t_);
   n = unsafe_load(n_)
   x = unsafe_wrap(Array, x_, (n,), own=false)
@@ -198,11 +198,11 @@ function unsafe_radauSoloutCallback(
 
   l_sol && println(lio,lprefix,"called with nr=",nr," told=",told,
                                " t=",t," x=",x)
-  
+
   cbi.tOld = told; cbi.tNew = t; cbi.xNew = x;
   cbi.cont_cont = cont_; cbi.cont_lrc = lrc_;
   cbi.output_data["nr"] = nr
-  
+
   ret = call_julia_output_fcn(cbi,OUTPUTFCN_CALL_STEP,told,t,x,
                               cbi.eval_sol_fcn)
 
@@ -216,15 +216,15 @@ function unsafe_radauSoloutCallback(
   else
     throw(InternalErrorODE(string("Unkown ret=",ret," of output function")))
   end
-  
+
   return nothing
 end
 
 """
-       function unsafe_radauSoloutCallback_c(cbi::CI, 
+       function unsafe_radauSoloutCallback_c(cbi::CI,
                fint_flag::FInt) where {FInt,CI}
   """
-function unsafe_radauSoloutCallback_c(cbi::CI, 
+function unsafe_radauSoloutCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt,CI}
   return @cfunction(unsafe_radauSoloutCallback, Cvoid, (Ptr{FInt},
     Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
@@ -233,12 +233,12 @@ function unsafe_radauSoloutCallback_c(cbi::CI,
 end
 
 """
-       function create_radau_eval_sol_fcn_closure(cbi::CI, d::FInt, 
+       function create_radau_eval_sol_fcn_closure(cbi::CI, d::FInt,
                method_cont::Ptr{Cvoid}) where {FInt<:FortranInt,
                                               CI<:RadauInternalCallInfos}
-  
+
   generates a eval_sol_fcn for radau and radau5.
-  
+
   Why is a closure needed? We need a function `eval_sol_fcn`
   that calls `CONTR5_` OR `CONTRA_` (with `ccall`).
   But `CONTR5_`/`CONTRA_` need the informations for the current state. This
@@ -246,7 +246,7 @@ end
   `RadauInternalCallInfos`. `eval_sol_fcn` needs to get this informations.
   Here comes `create_radau_eval_sol_fcn_closure` into play: this function
   takes call informations and generates a `eval_sol_fcn` with this data.
-  
+
   Why doesn't `unsafe_radauSoloutCallback` generate a closure (then
   the current state needs not to be saved in `RadauInternalCallInfos`)?
   Because then every call to `unsafe_radauSoloutCallback` would have
@@ -256,10 +256,10 @@ end
 
   For the typical calling sequence, see `RadauInternalCallInfos`.
   """
-function create_radau_eval_sol_fcn_closure(cbi::CI, d::FInt, 
+function create_radau_eval_sol_fcn_closure(cbi::CI, d::FInt,
         method_cont::Ptr{Cvoid}) where {FInt<:FortranInt,
                                        CI<:RadauInternalCallInfos}
-  
+
   function eval_sol_fcn_closure(s::Float64)
     (lio,l,lprefix)=(cbi.logio,cbi.loglevel,cbi.eval_lprefix)
     l_eval = l & LOG_EVALSOL>0
@@ -279,7 +279,7 @@ function create_radau_eval_sol_fcn_closure(cbi::CI, d::FInt,
           )
       end
     end
-    
+
     l_eval && println(lio,lprefix,"contr5 returned ",result)
     return result
   end
@@ -298,9 +298,9 @@ function extractCommonRadauOpt(
   OPT = nothing
   try
     # fill IWORK
-    OPT=OPT_TRANSJTOH; 
+    OPT=OPT_TRANSJTOH;
     transjtoh  = convert(Bool,getOption(opt,OPT,false))
-    @assert (!transjtoh) || 
+    @assert (!transjtoh) ||
             ( (!flag_jband) && (!flag_implct ))  string(
             "Does not work, if the jacobian is banded or if the system ",
             " has a mass matrix ( ≠ Id).")
@@ -311,7 +311,7 @@ function extractCommonRadauOpt(
 
     OPT=OPT_NEWTONSTARTZERO; zflag = convert(Bool,getOption(opt,OPT,false))
     args.IWORK[4] = zflag ? 1 : 0
-    
+
     OPT=OPT_DIMOFIND1VAR; args.IWORK[5] = convert(FInt,getOption(opt,OPT,d))
     @assert 0 < args.IWORK[5]
     OPT=OPT_DIMOFIND2VAR; args.IWORK[6] = convert(FInt,getOption(opt,OPT,0))
@@ -324,8 +324,8 @@ function extractCommonRadauOpt(
     @assert(d == args.IWORK[5]+args.IWORK[6]+args.IWORK[7],string(
       "Sum of dim1, dim2 and dim3 variables must be the dimension of the ",
       "system."))
-    
-    OPT = OPT_STEPSIZESTRATEGY; 
+
+    OPT = OPT_STEPSIZESTRATEGY;
     args.IWORK[8] = convert(FInt,getOption(opt,OPT,1))
     @assert args.IWORK[8] ∈ (1,2,)
 
@@ -336,7 +336,7 @@ function extractCommonRadauOpt(
     OPT = OPT_RHO
     args.WORK[2] = convert(Float64,getOption(opt,OPT,0.9))
     @assert 0.001 < args.WORK[2] < 1.0
-    
+
     OPT = OPT_JACRECOMPFACTOR
     args.WORK[3] = convert(Float64,getOption(opt,OPT,0.001))
     @assert !(args.WORK[3]==0)
@@ -348,10 +348,10 @@ function extractCommonRadauOpt(
     OPT = OPT_FREEZESSRIGHT
     args.WORK[6] = convert(Float64,getOption(opt,OPT,1.2))
     @assert args.WORK[6] ≥ 1.0
-    
+
     OPT=OPT_MAXSS; args.WORK[7]=convert(Float64,getOption(opt,OPT,T-t0))
     @assert 0 ≠ args.WORK[7]
-    
+
     OPT=OPT_SSMINSEL; args.WORK[8]=convert(Float64,getOption(opt,OPT,0.2))
     @assert args.WORK[8] ≤ 1
     OPT=OPT_SSMAXSEL; args.WORK[9]=convert(Float64,getOption(opt,OPT,8.0))
@@ -369,7 +369,7 @@ function extractCommonRadauOpt(
   rhs_lprefix = "unsafe_HW2RHSCallback: "
   out_lprefix = "unsafe_radauSoloutCallback: "
   eval_lprefix = "eval_sol_fcn_closure: "
-  
+
   return (rhs_lprefix,out_lprefix,eval_lprefix)
 end
 
@@ -377,7 +377,7 @@ end
   calls the radau5 or radau solver after all solver arguments are prepared.
   """
 function doRadauSolverCall(
-        lio,l,l_g,l_solver,lprefix, d::FInt,M1::FInt,M2::FInt, 
+        lio,l,l_g,l_solver,lprefix, d::FInt,M1::FInt,M2::FInt,
         rhs,rhs_mode,rhs_lprefix, output_mode,output_fcn,out_lprefix,
         eval_lprefix,massmatrix, jacobimatrix,jacobibandstruct,
         jac_lprefix,args,method_solver,method_cont) where FInt<:FortranInt
@@ -430,7 +430,7 @@ function doRadauSolverCall(
     args.N, args.FCN,
     args.t, args.x, args.tEnd,
     args.H,
-    args.RTOL, args.ATOL, args.ITOL, 
+    args.RTOL, args.ATOL, args.ITOL,
     args.JAC, args.IJAC, args.MLJAC, args.MUJAC,
     args.MAS, args.IMAS, args.MLMAS, args.MUMAS,
     args.SOLOUT, args.IOUT,
@@ -478,36 +478,36 @@ function radau5_i32(rhs, t0::Real, T::Real,
 end
 
 """
-       function radau5_impl(rhs, 
-               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+       function radau5_impl(rhs,
+               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
                args::RadauArguments{FInt}) where FInt<:FortranInt
-  
+
   implementation of radau5 for FInt.
   """
-function radau5_impl(rhs, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function radau5_impl(rhs,
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::RadauArguments{FInt}) where FInt<:FortranInt
 
   (lio,l,l_g,l_solver,lprefix) = solver_start("radau5",rhs,t0,T,x0,opt)
-  
+
   (method_radau5, method_contr5) = getAllMethodPtrs(
      (FInt == Int64) ? DL_RADAU5 : DL_RADAU5_I32 )
-  
+
   (d,nrdense,scalarFlag,rhs_mode,output_mode,output_fcn) =
     solver_extract_commonOpt(t0,T,x0,opt,args)
-  
+
   args.ITOL = [ scalarFlag ? 0 : 1 ]
   args.IOUT = [ output_mode == OUTPUTFCN_NEVER ? 0 : 1 ]
 
   (M1,M2,NM1) = extractSpecialStructureOpt(d,opt)
   massmatrix = extractMassMatrix(M1,M2,NM1,args,opt)
-  
+
   (jacobimatrix,jacobibandstruct,jac_lprefix) =
     extractJacobiOpt(d,M1,M2,NM1,args,opt)
-  
+
   flag_implct = args.IMAS[1] ≠ 0
   flag_jband = args.MLJAC[1] < NM1
-  
+
   # WORK memory
   ljac = flag_jband ? 1+args.MLJAC[1]+args.MUJAC[1] : NM1
   lmas = (!flag_implct) ? 0 :
@@ -523,7 +523,7 @@ function radau5_impl(rhs,
   args.IWORK = zeros(FInt,args.LIWORK[1])
 
   args.IWORK[9] = M1; args.IWORK[10] = M2
-  (rhs_lprefix,out_lprefix,eval_lprefix) = 
+  (rhs_lprefix,out_lprefix,eval_lprefix) =
     extractCommonRadauOpt(d,T,t0,args,opt)
 
   OPT = nothing
@@ -532,7 +532,7 @@ function radau5_impl(rhs,
     @assert 0 < args.IWORK[3]
 
     OPT = OPT_NEWTONSTOPCRIT
-    args.WORK[4] = convert(Float64,getOption(opt,OPT, 
+    args.WORK[4] = convert(Float64,getOption(opt,OPT,
                            max(10*args.WORK[1]/args.RTOL[1],
                                min(0.03,sqrt(args.RTOL[1])))))
     @assert args.WORK[4]>args.WORK[1]/args.RTOL[1]
@@ -551,11 +551,11 @@ end
        function radau(rhs, t0::Real, T::Real,
                        x0::Vector, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
-       
+
        function radau5(rhs, t0::Real, T::Real,
                        x0::Vector, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
-  
+
   `retcode` can have the following values:
 
         1: computation successful
@@ -564,18 +564,18 @@ end
        -2: larger OPT_MAXSTEPS is needed
        -3: step size becomes too small
        -4: matrix is repeatedly singular
-  
+
   main call for using Fortran radau or radau5 solver.
-  
+
   This solver support problems with special structure, see
   `help_specialstructure`.
-  
+
   Remark:
-  Because radau and radau5 are collocation methods, there is no difference 
+  Because radau and radau5 are collocation methods, there is no difference
   in the computational costs for OUTPUTFCN_WODENSE and OUTPUTFCN_DENSE.
-  
+
   In `opt` the following options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -755,33 +755,33 @@ function radau_i32(rhs, t0::Real, T::Real,
 end
 
 """
-       function radau_impl(rhs, 
-               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+       function radau_impl(rhs,
+               t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
                args::RadauArguments{FInt}) where FInt<:FortranInt
-  
+
   implementation of radau for FInt.
   """
-function radau_impl(rhs, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function radau_impl(rhs,
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::RadauArguments{FInt}) where FInt<:FortranInt
 
   (lio,l,l_g,l_solver,lprefix) = solver_start("radau5",rhs,t0,T,x0,opt)
-  
+
   (method_radau, method_contra) = getAllMethodPtrs(
      (FInt == Int64) ? DL_RADAU : DL_RADAU_I32 )
-  
+
   (d,nrdense,scalarFlag,rhs_mode,output_mode,output_fcn) =
     solver_extract_commonOpt(t0,T,x0,opt,args)
-  
+
   args.ITOL = [ scalarFlag ? 0 : 1 ]
   args.IOUT = [ output_mode == OUTPUTFCN_NEVER ? 0 : 1 ]
 
   (M1,M2,NM1) = extractSpecialStructureOpt(d,opt)
   massmatrix = extractMassMatrix(M1,M2,NM1,args,opt)
-  
+
   (jacobimatrix,jacobibandstruct,jac_lprefix) =
     extractJacobiOpt(d,M1,M2,NM1,args,opt)
-  
+
   flag_implct = args.IMAS[1] ≠ 0
   flag_jband = args.MLJAC[1] < NM1
 
@@ -799,31 +799,31 @@ function radau_impl(rhs,
   lmas = (!flag_implct) ? 0 :
          (args.MLMAS[1] == NM1) ? NM1 : 1+args.MLMAS[1]+args.MUMAS[1]
   le   = flag_jband ? 1+2*args.MLJAC[1]+args.MUJAC[1] : NM1
-  
+
   args.LWORK = [ (M1==0) ? d*(ljac+lmas+NSMAX*le+3*NSMAX+3)+20 :
                            d*(ljac+3*NSMAX+3)+NM1*(lmas+NSMAX*le)+20 ]
   args.WORK = zeros(Float64,args.LWORK[1])
-   
+
   # IWORK memoery
   args.LIWORK = [ (2+(NSMAX-1)÷2)*d+20  ]
   args.IWORK = zeros(FInt,args.LIWORK[1])
 
   args.IWORK[9] = M1; args.IWORK[10] = M2
-  (rhs_lprefix,out_lprefix,eval_lprefix) = 
+  (rhs_lprefix,out_lprefix,eval_lprefix) =
     extractCommonRadauOpt(d,T,t0,args,opt)
 
   try
     OPT=OPT_MAXNEWTONITER; args.IWORK[3] = convert(FInt,getOption(opt,OPT,7))
     @assert 0 < args.IWORK[3] < 50
-    
+
     OPT = OPT_MINSTAGES; NSMIN = convert(FInt,getOption(opt,OPT,3))
     @assert NSMIN ∈ (1,3,5,7) && NSMIN ≤ NSMAX
     args.IWORK[11] = NSMIN
-    
+
     OPT = OPT_INITSTAGES; NSINIT = convert(FInt,getOption(opt,OPT,NSMIN))
     @assert NSINIT ∈ (1,3,5,7) && NSMIN ≤ NSINIT ≤ NSMAX
     args.IWORK[13] = NSINIT
-    
+
     OPT = OPT_ORDERINCFACTOR
     orderincfactor = convert(Float64,getOption(opt,OPT,0.002))
     OPT = OPT_ORDERDECFACTOR
@@ -832,19 +832,19 @@ function radau_impl(rhs,
     @assert 0 < orderincfactor < orderdecfactor
     args.WORK[10] = orderincfactor
     args.WORK[11] = orderdecfactor
-    
+
     OPT = OPT_ORDERDECSTEPFAC1
     orderdecstepfac1 = convert(Float64,getOption(opt,OPT,1.2))
     OPT = OPT_ORDERDECSTEPFAC2
     orderdecstepfac2 = convert(Float64,getOption(opt,OPT,0.8))
     OPT = string(OPT_ORDERDECSTEPFAC1," & ",OPT_ORDERDECSTEPFAC2)
     @assert 0 < orderdecstepfac2 < orderdecstepfac1
-    args.WORK[12] = orderdecstepfac1 
+    args.WORK[12] = orderdecstepfac1
     args.WORK[13] = orderdecstepfac2
   catch e
     throw(ArgumentErrorODE("Option '$OPT': Not valid",:opt,e))
   end
-  
+
   return doRadauSolverCall(lio,l,l_g,l_solver,lprefix,d,M1,M2,
          rhs,rhs_mode,rhs_lprefix,output_mode,output_fcn,
          out_lprefix,eval_lprefix,massmatrix,
@@ -852,8 +852,8 @@ function radau_impl(rhs,
          method_radau,method_contra)
 end
 
-"""  
-  ## Compile RADAU5 
+"""
+  ## Compile RADAU5
 
   The julia ODEInterface tries to compile and link the solvers
   automatically at the build-time of this module. The following
@@ -861,101 +861,101 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_radau5_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile RADAU5 with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapackc.o lapackc.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o radau5.o radau5.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
-       gfortran -shared -fPIC -o radau5.so 
+       gfortran -shared -fPIC -o radau5.so
                 radau5.o dc_lapack.o lapack.o lapackc.o
        gfortran -shared -fPIC -o radau5.dylib
                 radau5.o dc_lapack.o lapack.o lapackc.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile RADAU5 with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapackc.o lapackc.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o radau5.o radau5.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
-       gfortran -shared -o radau5.so 
+
+       gfortran -shared -o radau5.so
                 radau5.o dc_lapack.o lapack.o lapackc.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile RADAU5 with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
-                -o lapackc_i32.o lapackc.f 
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
+                -o lapackc_i32.o lapackc.f
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o radau5_i32.o radau5.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
-       gfortran -shared -fPIC -o radau5_i32.so 
+
+       gfortran -shared -fPIC -o radau5_i32.so
                  radau5_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
        gfortran -shared -fPIC -o radau5_i32.dylib
                  radau5_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile RADAU5 with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
-                -o lapackc_i32.o lapackc.f 
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
+                -o lapackc_i32.o lapackc.f
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o radau5_i32.o radau5.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o radau5_i32.dll
                  radau5_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
-  
+
   """
 function help_radau5_compile()
   return Docs.doc(help_radau5_compile)
@@ -967,8 +967,8 @@ end
 
 @doc(@doc(hw_license),help_radau5_license)
 
-"""  
-  ## Compile RADAU 
+"""
+  ## Compile RADAU
 
   The julia ODEInterface tries to compile and link the solvers
   automatically at the build-time of this module. The following
@@ -976,101 +976,101 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_radau_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile RADAU with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapackc.o lapackc.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o radau.o radau.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
-       gfortran -shared -fPIC -o radau.so 
+       gfortran -shared -fPIC -o radau.so
                 radau.o dc_lapack.o lapack.o lapackc.o
        gfortran -shared -fPIC -o radau.dylib
                 radau.o dc_lapack.o lapack.o lapackc.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile RADAU with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapackc.o lapackc.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o radau.o radau.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
-       gfortran -shared -o radau.so 
+
+       gfortran -shared -o radau.so
                 radau.o dc_lapack.o lapack.o lapackc.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile RADAU with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
-                -o lapackc_i32.o lapackc.f 
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
+                -o lapackc_i32.o lapackc.f
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o radau_i32.o radau.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
-       gfortran -shared -fPIC -o radau_i32.so 
+
+       gfortran -shared -fPIC -o radau_i32.so
                  radau_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
        gfortran -shared -fPIC -o radau_i32.dylib
                  radau_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile RADAU with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
-                -o lapackc_i32.o lapackc.f 
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
+                -o lapackc_i32.o lapackc.f
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o radau_i32.o radau.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o radau_i32.dll
                  radau_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
-  
+
   """
 function help_radau_compile()
   return Docs.doc(help_radau_compile)
@@ -1086,14 +1086,14 @@ end
 push!(solverInfo,
   SolverInfo("radau5",
     "Implicit Runge-Kutta method (Radau IIA) of order 5",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_M1, :OPT_M2,
           :OPT_MASSMATRIX,
           :OPT_TRANSJTOH, :OPT_MAXSTEPS, :OPT_MAXNEWTONITER,
-          :OPT_NEWTONSTARTZERO, 
+          :OPT_NEWTONSTARTZERO,
           :OPT_DIMOFIND1VAR, :OPT_DIMOFIND2VAR, :OPT_DIMOFIND3VAR,
-          :OPT_STEPSIZESTRATEGY, 
+          :OPT_STEPSIZESTRATEGY,
           :OPT_RHO, :OPT_JACRECOMPFACTOR, :OPT_NEWTONSTOPCRIT,
           :OPT_FREEZESSLEFT, :OPT_FREEZESSRIGHT,
           :OPT_SSMINSEL, :OPT_SSMAXSEL, :OPT_INITIALSS,
@@ -1117,14 +1117,14 @@ push!(solverInfo,
 push!(solverInfo,
   SolverInfo("radau",
     "Implicit Runge-Kutta method (Radau IIA) of variable order ∈ (5,9,13)",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_M1, :OPT_M2,
           :OPT_MASSMATRIX,
           :OPT_TRANSJTOH, :OPT_MAXSTEPS, :OPT_MAXNEWTONITER,
-          :OPT_NEWTONSTARTZERO, 
+          :OPT_NEWTONSTARTZERO,
           :OPT_DIMOFIND1VAR, :OPT_DIMOFIND2VAR, :OPT_DIMOFIND3VAR,
-          :OPT_STEPSIZESTRATEGY, 
+          :OPT_STEPSIZESTRATEGY,
           :OPT_RHO, :OPT_JACRECOMPFACTOR, :OPT_NEWTONSTOPCRIT,
           :OPT_FREEZESSLEFT, :OPT_FREEZESSRIGHT,
           :OPT_SSMINSEL, :OPT_SSMAXSEL, :OPT_INITIALSS,

--- a/src/Rodas.jl
+++ b/src/Rodas.jl
@@ -29,7 +29,7 @@ end
 
 """
   Type encapsulating all required data for Rodas-Solver-Callbacks.
-  
+
   We have the typical calling stack:
 
        rodas
@@ -66,7 +66,7 @@ mutable struct RodasInternalCallInfos{FInt<:FortranInt, RHS_F,
   M1           :: FInt
   M2           :: FInt
   # RHS
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   # RHS time derivative
@@ -77,7 +77,7 @@ mutable struct RodasInternalCallInfos{FInt<:FortranInt, RHS_F,
   output_fcn   :: OUT_F                 # the output function to call
   output_data  :: Dict                  # extra_data for output_fcn
   out_lprefix  :: AbstractString        # saved log-prefix for solout
-  eval_sol_fcn :: Function              # eval_sol_fcn 
+  eval_sol_fcn :: Function              # eval_sol_fcn
   eval_lprefix :: AbstractString        # saved log-prefix for eval_sol
   tOld         :: Float64               # tOld and
   tNew         :: Float64               # tNew and
@@ -95,11 +95,11 @@ mutable struct RodasInternalCallInfos{FInt<:FortranInt, RHS_F,
 end
 
 """
-       mutable struct RodasArguments{FInt<:FortranInt} <: 
+       mutable struct RodasArguments{FInt<:FortranInt} <:
                 AbstractArgumentsODESolver{FInt}
-  
+
   Stores Arguments for Rodas solver.
-  
+
   FInt is the Integer type used for the fortran compilation.
   """
 mutable struct RodasArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
@@ -141,33 +141,33 @@ end
 
 """
        function unsafe_rodasSoloutCallback(
-               nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-               x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-               n_::Ptr{FInt}, rpar_::Ptr{Float64}, cbi::CI, 
-               irtrn_::Ptr{FInt}) where {FInt<:FortranInt, 
+               nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+               x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt},
+               n_::Ptr{FInt}, rpar_::Ptr{Float64}, cbi::CI,
+               irtrn_::Ptr{FInt}) where {FInt<:FortranInt,
                                          CI<:RodasInternalCallInfos}
-  
+
   This is the solout given as callback to Fortran-rodas.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
 
   This function saves the state informations of the solver in
   `RodasInternalCallInfos`, where they can be found by
   the `eval_sol_fcn`, see `create_rodas_eval_sol_fcn_closure`.
-  
+
   Then the user-supplied `output_fcn` is called (which in turn can use
   `eval_sol_fcn`, to evalutate the solution at intermediate points).
-  
+
   The return value of the `output_fcn` is propagated to `RODAS_`.
-  
+
   For the typical calling sequence, see `RodasInternalCallInfos`.
   """
 function unsafe_rodasSoloutCallback(
-        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-        x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-        n_::Ptr{FInt}, rpar_::Ptr{Float64}, cbi::CI, 
-        irtrn_::Ptr{FInt}) where {FInt<:FortranInt, 
+        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+        x_::Ptr{Float64}, cont_::Ptr{Float64}, lrc_::Ptr{FInt},
+        n_::Ptr{FInt}, rpar_::Ptr{Float64}, cbi::CI,
+        irtrn_::Ptr{FInt}) where {FInt<:FortranInt,
                                   CI<:RodasInternalCallInfos}
 
   nr = unsafe_load(nr_); told = unsafe_load(told_); t = unsafe_load(t_)
@@ -203,24 +203,24 @@ function unsafe_rodasSoloutCallback(
 end
 
 """
-       function unsafe_rodasSoloutCallback_c(cbi::CI, 
+       function unsafe_rodasSoloutCallback_c(cbi::CI,
                fint_flag::FInt) where {FInt,CI}
   """
-function unsafe_rodasSoloutCallback_c(cbi::CI, 
+function unsafe_rodasSoloutCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt,CI}
   return @cfunction(unsafe_rodasSoloutCallback, Cvoid, (Ptr{FInt},
-    Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, 
-    Ptr{Float64}, Ptr{FInt}, 
+    Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
+    Ptr{Float64}, Ptr{FInt},
     Ptr{FInt}, Ptr{Float64}, Ref{CI}, Ptr{FInt}))
 end
 
 """
-       function create_rodas_eval_sol_fcn_closure(cbi::CI, d::FInt, 
-               method_contro::Ptr{Cvoid}) where {FInt<:FortranInt, 
+       function create_rodas_eval_sol_fcn_closure(cbi::CI, d::FInt,
+               method_contro::Ptr{Cvoid}) where {FInt<:FortranInt,
                                                 CI<:RodasInternalCallInfos}
-  
+
   generates a eval_sol_fcn for rodas.
-  
+
   Why is a closure needed? We need a function `eval_sol_fcn`
   that calls `CONTRO_` (with `ccall`).
   But `CONTRO_` needs the informations for the current state. This
@@ -228,7 +228,7 @@ end
   `RodasInternalCallInfos`. `eval_sol_fcn` needs to get this informations.
   Here comes `create_rodas_eval_sol_fcn_closure` into play: this function
   takes the call informations and generates a `eval_sol_fcn` with this data.
-  
+
   Why doesn't `unsafe_rodasSoloutCallback` generate a closure (then
   the current state needs not to be saved in `RodasInternalCallInfos`)?
   Because then every call to `unsafe_rodasSoloutCallback` would have
@@ -238,10 +238,10 @@ end
 
   For the typical calling sequence, see `RodasInternalCallInfos`.
   """
-function create_rodas_eval_sol_fcn_closure(cbi::CI, d::FInt, 
-        method_contro::Ptr{Cvoid}) where {FInt<:FortranInt, 
+function create_rodas_eval_sol_fcn_closure(cbi::CI, d::FInt,
+        method_contro::Ptr{Cvoid}) where {FInt<:FortranInt,
                                          CI<:RodasInternalCallInfos}
-  
+
   function eval_sol_fcn_closure(s::Float64)
     (lio,l,lprefix)=(cbi.logio,cbi.loglevel,cbi.eval_lprefix)
     l_eval = l & LOG_EVALSOL>0
@@ -260,7 +260,7 @@ function create_rodas_eval_sol_fcn_closure(cbi::CI, d::FInt,
           cbi.cont_i,cbi.cont_s, cbi.cont_cont, cbi.cont_lrc)
       end
     end
-    
+
     l_eval && println(lio,lprefix,"contro returned ",result)
     return result
   end
@@ -272,7 +272,7 @@ end
         function rodas(rhs, t0::Real, T::Real,
                        x0::Vector, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
-  
+
 
   `retcode` can have the following values:
 
@@ -285,9 +285,9 @@ end
 
   This solver support problems with special structure, see
   `help_specialstructure`.
-  
+
   In `opt` the following options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -399,8 +399,8 @@ function rodas_i32(rhs, t0::Real, T::Real,
   return rodas_impl(rhs,t0,T,x0,opt,RodasArguments{Int32}(Int32(0)))
 end
 
-function rodas_impl(rhs, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function rodas_impl(rhs,
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::RodasArguments{FInt}) where FInt<:FortranInt
 
   (lio,l,l_g,l_solver,lprefix) = solver_start("rodas",rhs,t0,T,x0,opt)
@@ -452,11 +452,11 @@ function rodas_impl(rhs,
     OPT=OPT_METHODCHOICE; args.IWORK[2] = convert(FInt,getOption(opt,OPT,1))
     @assert 1 ≤ args.IWORK[2] ≤ 3
 
-    OPT = OPT_STEPSIZESTRATEGY; 
+    OPT = OPT_STEPSIZESTRATEGY;
     args.IWORK[3] = convert(FInt,getOption(opt,OPT,1))
     @assert args.IWORK[3] ∈ (1,2,)
 
-    args.IWORK[9] = M1 
+    args.IWORK[9] = M1
     args.IWORK[10] = M2
 
     OPT=OPT_EPS; args.WORK[1]=convert(Float64,getOption(opt,OPT,1e-16))
@@ -537,7 +537,7 @@ function rodas_impl(rhs,
     args.N, args.FCN, args.IFCN,
     args.t, args.x, args.tEnd,
     args.H,
-    args.RTOL, args.ATOL, args.ITOL, 
+    args.RTOL, args.ATOL, args.ITOL,
     args.JAC, args.IJAC, args.MLJAC, args.MUJAC,
     args.DFX, args.IDFX,
     args.MAS, args.IMAS, args.MLMAS, args.MUMAS,
@@ -579,91 +579,91 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_rodas_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile RODAS with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o rodas.o rodas.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
-       gfortran -shared -fPIC -o rodas.so 
+       gfortran -shared -fPIC -o rodas.so
                 rodas.o dc_lapack.o lapack.o
        gfortran -shared -fPIC -o rodas.dylib
                 rodas.o dc_lapack.o lapack.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile RODAS with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o rodas.o rodas.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
-       gfortran -shared -o rodas.so 
+
+       gfortran -shared -o rodas.so
                 rodas.o dc_lapack.o lapack.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile RODAS with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o rodas_i32.o rodas.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
-       gfortran -shared -fPIC -o rodas_i32.so 
+
+       gfortran -shared -fPIC -o rodas_i32.so
                  rodas_i32.o dc_lapack_i32.o lapack_i32.o
        gfortran -shared -fPIC -o rodas_i32.dylib
                  rodas_i32.o dc_lapack_i32.o lapack_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile RODAS with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o rodas_i32.o rodas.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o rodas_i32.dll
                  rodas_i32.o dc_lapack_i32.o lapack_i32.o
-  
+
   """
 function help_rodas_compile()
   return Docs.doc(help_rodas_compile)
@@ -679,8 +679,8 @@ end
 push!(solverInfo,
   SolverInfo("rodas",
     "Rosenbrock method of order 4(3)",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_M1, :OPT_M2,
           :OPT_RHSAUTONOMOUS,
           :OPT_MASSMATRIX,

--- a/src/SLATECcommon.jl
+++ b/src/SLATECcommon.jl
@@ -93,7 +93,7 @@ end
   """
 function extractSlatecOutputAtTimes(t0, T, opt::AbstractOptionsODE)
   t_values = getOption(opt, OPT_OUTPUTATTIMES, nothing)
-  if t_values === nothing 
+  if t_values === nothing
         t_values = zeros(Float64, 0)
   end
   output_attimes_given = length(t_values)>0
@@ -113,7 +113,7 @@ function extractSlatecOutputAtTimes(t0, T, opt::AbstractOptionsODE)
     if any( x -> sign(x) != s, diff(t_values) )
       throw(ArgumentErrorODE(string("Because sign(T-t0)=sign($T-$t0)=$s ",
         "the vector in OPT_OUTPUTATTIMES has to be ",
-        (T ≥ t0 ? "ascending" : "descending"), 
+        (T ≥ t0 ? "ascending" : "descending"),
         ". But this is not the case."),:opt))
     end
     if s*(t0-t_values[1]) ≥ 0 || s*(t_values[end]-T) ≥ 0
@@ -127,17 +127,17 @@ end
 
 """
        function unsafe_SLATEC1RHSCallback(
-               t_::Ptr{Float64}, x_::Ptr{Float64}, f_::Ptr{Float64}, 
+               t_::Ptr{Float64}, x_::Ptr{Float64}, f_::Ptr{Float64},
                rpar_::Ptr{Float64}, cbi::CI) where CI<:ODEinternalCallInfos
-  
+
   This is the right-hand side given as callback to SLATEC solvers,
   e.g. ddeabm.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-arguments.
   """
 function unsafe_SLATEC1RHSCallback(
-        t_::Ptr{Float64}, x_::Ptr{Float64}, f_::Ptr{Float64}, 
+        t_::Ptr{Float64}, x_::Ptr{Float64}, f_::Ptr{Float64},
         rpar_::Ptr{Float64}, cbi::CI) where CI<:ODEinternalCallInfos
   n = cbi.N
   t = unsafe_load(t_)
@@ -150,13 +150,13 @@ function unsafe_SLATEC1RHSCallback(
 end
 
 """
-       function unsafe_SLATEC1RHSCallback_c(cbi::CI, 
+       function unsafe_SLATEC1RHSCallback_c(cbi::CI,
                fint_flag::FInt) where {FInt,CI}
           -> C-callable function pointer
 
   This method generates a Pointer to C-callable instructions.
   The two method type parameters `FInt` and `CI` are important:
-  `FInt` is the used Fortran integer type and `CI` is the used 
+  `FInt` is the used Fortran integer type and `CI` is the used
   `ODEinternalCallInfos` *SubType*.
   Because `unsafe_SLATEC1RHSCallback` is a parameterized method,
   special variants are compiled, if `FInt` or `CI` changes.
@@ -165,14 +165,14 @@ end
   calls to such Julia-functions can be resolved at compile-time
   (instead of dynamic calls during run-time).
   """
-function unsafe_SLATEC1RHSCallback_c(cbi::CI, 
+function unsafe_SLATEC1RHSCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt,CI}
   return @cfunction(unsafe_SLATEC1RHSCallback, Cvoid, (Ptr{Float64},
     Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, Ref{CI}))
 end
 
 
-function unsafe_SLATEC1JacCallback(t_::Ptr{Float64}, x_::Ptr{Float64}, 
+function unsafe_SLATEC1JacCallback(t_::Ptr{Float64}, x_::Ptr{Float64},
         dfx_::Ptr{Float64}, dfx_rows_::Ptr{FInt}, rpar_::Ptr{Float64},
         cbi::CI) where {FInt<:FortranInt, CI<:ODEinternalCallInfos}
   n = cbi.N
@@ -205,11 +205,11 @@ function unsafe_SLATEC1JacCallback(t_::Ptr{Float64}, x_::Ptr{Float64},
 end
 
 """
-       function unsafe_SLATEC1JacCallback_c(cbi::CI, 
+       function unsafe_SLATEC1JacCallback_c(cbi::CI,
                fint_flag::FInt) where {FInt, CI}
           -> C-callable function pointer
   """
-function unsafe_SLATEC1JacCallback_c(cbi::CI, 
+function unsafe_SLATEC1JacCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt, CI}
   return @cfunction(unsafe_SLATEC1JacCallback, Cvoid, (Ptr{Float64},
     Ptr{Float64}, Ptr{Float64}, Ptr{FInt}, Ptr{Float64}, Ref{CI}))

--- a/src/Seulex.jl
+++ b/src/Seulex.jl
@@ -29,10 +29,10 @@ end
 
 """
   Type encapsulating all required data for Seulex-Solver-Callbacks.
-  
+
   We have the typical calling stack:
 
-       seulex       
+       seulex
            call_julia_output_fcn(  ... INIT ... )
                output_fcn ( ... INIT ...)
            ccall( SEULEX_  ... )
@@ -62,7 +62,7 @@ mutable struct SeulexInternalCallInfos{FInt<:FortranInt, RHS_F,
   M1           :: FInt
   M2           :: FInt
   # RHS:
-  rhs          :: RHS_F                 # right-hand-side 
+  rhs          :: RHS_F                 # right-hand-side
   rhs_mode     :: RHS_CALL_MODE         # how to call rhs
   rhs_lprefix  :: AbstractString        # saved log-prefix for rhs
   # SOLOUT & output function
@@ -70,7 +70,7 @@ mutable struct SeulexInternalCallInfos{FInt<:FortranInt, RHS_F,
   output_fcn   :: OUT_F                 # the output function to call
   output_data  :: Dict                  # extra_data for output_fcn
   out_lprefix  :: AbstractString        # saved log-prefix for solout
-  eval_sol_fcn :: Function              # eval_sol_fcn 
+  eval_sol_fcn :: Function              # eval_sol_fcn
   eval_lprefix :: AbstractString        # saved log-prefix for eval_sol
   tOld         :: Float64               # tOld and
   tNew         :: Float64               # tNew and
@@ -90,11 +90,11 @@ mutable struct SeulexInternalCallInfos{FInt<:FortranInt, RHS_F,
 end
 
 """
-       mutable struct SeulexArguments{FInt<:FortranInt} <: 
+       mutable struct SeulexArguments{FInt<:FortranInt} <:
                 AbstractArgumentsODESolver{FInt}
-  
+
   Stores Arguments for Seulex solver.
-  
+
   FInt is the Integer type used for the fortran compilation.
   """
 mutable struct SeulexArguments{FInt<:FortranInt} <: AbstractArgumentsODESolver{FInt}
@@ -133,35 +133,35 @@ end
 
 """
        function unsafe_seulexSoloutCallback(
-               nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-               x_::Ptr{Float64}, rc_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-               ic_::Ptr{FInt}, lic_::Ptr{FInt}, n_::Ptr{FInt}, 
-               rpar_::Ptr{Float64}, cbi::CI, 
-               irtrn_::Ptr{FInt}) where {FInt<:FortranInt, 
+               nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+               x_::Ptr{Float64}, rc_::Ptr{Float64}, lrc_::Ptr{FInt},
+               ic_::Ptr{FInt}, lic_::Ptr{FInt}, n_::Ptr{FInt},
+               rpar_::Ptr{Float64}, cbi::CI,
+               irtrn_::Ptr{FInt}) where {FInt<:FortranInt,
                                          CI<:SeulexInternalCallInfos}
-  
+
   This is the solout given as callback to Fortran-seulex.
-  
-  The `unsafe` prefix in the name indicates that no validations are 
+
+  The `unsafe` prefix in the name indicates that no validations are
   performed on the `Ptr`-pointers.
 
   This function saves the state informations of the solver in
   `SeulexInternalCallInfos`, where they can be found by
   the `eval_sol_fcn`, see `create_seulex_eval_sol_fcn_closure`.
-  
+
   Then the user-supplied `output_fcn` is called (which in turn can use
   `eval_sol_fcn`, to evalutate the solution at intermediate points).
-  
+
   The return value of the `output_fcn` is propagated to `SEULEX_`.
-  
+
   For the typical calling sequence, see `SeulexInternalCallInfos`.
   """
 function unsafe_seulexSoloutCallback(
-        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64}, 
-        x_::Ptr{Float64}, rc_::Ptr{Float64}, lrc_::Ptr{FInt}, 
-        ic_::Ptr{FInt}, lic_::Ptr{FInt}, n_::Ptr{FInt}, 
-        rpar_::Ptr{Float64}, cbi::CI, 
-        irtrn_::Ptr{FInt}) where {FInt<:FortranInt, 
+        nr_::Ptr{FInt}, told_::Ptr{Float64}, t_::Ptr{Float64},
+        x_::Ptr{Float64}, rc_::Ptr{Float64}, lrc_::Ptr{FInt},
+        ic_::Ptr{FInt}, lic_::Ptr{FInt}, n_::Ptr{FInt},
+        rpar_::Ptr{Float64}, cbi::CI,
+        irtrn_::Ptr{FInt}) where {FInt<:FortranInt,
                                   CI<:SeulexInternalCallInfos}
 
   nr = unsafe_load(nr_); told = unsafe_load(told_); t = unsafe_load(t_)
@@ -174,9 +174,9 @@ function unsafe_seulexSoloutCallback(
 
   l_sol && println(lio,lprefix,"called with nr=",nr," told=",told,
                                " t=",t," x=",x)
-  
+
   cbi.tOld = told; cbi.tNew = t; cbi.xNew = x;
-  cbi.cont_rc = rc_; cbi.cont_lrc = lrc_; 
+  cbi.cont_rc = rc_; cbi.cont_lrc = lrc_;
   cbi.cont_ic = ic_; cbi.cont_lic = lic_;
   cbi.output_data["nr"] = nr
 
@@ -193,29 +193,29 @@ function unsafe_seulexSoloutCallback(
   else
     throw(InternalErrorODE(string("Unkown ret=",ret," of output function")))
   end
-  
+
   return nothing
 end
 
 """
-       function unsafe_seulexSoloutCallback_c(cbi::CI, 
+       function unsafe_seulexSoloutCallback_c(cbi::CI,
                fint_flag::FInt) where {FInt,CI}
   """
-function unsafe_seulexSoloutCallback_c(cbi::CI, 
+function unsafe_seulexSoloutCallback_c(cbi::CI,
         fint_flag::FInt) where {FInt,CI}
   return @cfunction(unsafe_seulexSoloutCallback, Cvoid, (Ptr{FInt},
-    Ptr{Float64}, Ptr{Float64}, Ptr{Float64}, 
+    Ptr{Float64}, Ptr{Float64}, Ptr{Float64},
     Ptr{Float64}, Ptr{FInt}, Ptr{FInt}, Ptr{FInt},
     Ptr{FInt}, Ptr{Float64}, Ref{CI}, Ptr{FInt}))
 end
 
 """
-       function create_seulex_eval_sol_fcn_closure(cbi::CI, d::FInt, 
-               method_contex::Ptr{Cvoid}) where {FInt<:FortranInt, 
+       function create_seulex_eval_sol_fcn_closure(cbi::CI, d::FInt,
+               method_contex::Ptr{Cvoid}) where {FInt<:FortranInt,
                                                 CI<:SeulexInternalCallInfos}
-  
+
   generates a eval_sol_fcn for seulex.
-  
+
   Why is a closure needed? We need a function `eval_sol_fcn`
   that calls `CONTEX_` (with `ccall`).
   But `CONTEX_` needs the informations for the current state. This
@@ -223,7 +223,7 @@ end
   `SeulexInternalCallInfos`. `eval_sol_fcn` needs to get this informations.
   Here comes `create_seulex_eval_sol_fcn_closure` into play: this function
   takes the call informations and generates a `eval_sol_fcn` with this data.
-  
+
   Why doesn't `unsafe_seulexSoloutCallback` generate a closure (then
   the current state needs not to be saved in `SeulexInternalCallInfos`)?
   Because then every call to `unsafe_seulexSoloutCallback` would have
@@ -233,10 +233,10 @@ end
 
   For the typical calling sequence, see `SeulexInternalCallInfos`.
   """
-function create_seulex_eval_sol_fcn_closure(cbi::CI, d::FInt, 
-        method_contex::Ptr{Cvoid}) where {FInt<:FortranInt, 
+function create_seulex_eval_sol_fcn_closure(cbi::CI, d::FInt,
+        method_contex::Ptr{Cvoid}) where {FInt<:FortranInt,
                                          CI<:SeulexInternalCallInfos}
-  
+
   function eval_sol_fcn_closure(s::Float64)
     (lio,l,lprefix)=(cbi.logio,cbi.loglevel,cbi.eval_lprefix)
     l_eval = l & LOG_EVALSOL>0
@@ -251,13 +251,13 @@ function create_seulex_eval_sol_fcn_closure(cbi::CI, d::FInt,
       for k = 1:d
         cbi.cont_i[1] = k
         result[k] = ccall(method_contex,Float64,
-          (Ptr{FInt}, Ptr{Float64}, Ptr{Float64}, Ptr{FInt}, 
+          (Ptr{FInt}, Ptr{Float64}, Ptr{Float64}, Ptr{FInt},
            Ptr{FInt}, Ptr{FInt},),
           cbi.cont_i,cbi.cont_s, cbi.cont_rc, cbi.cont_lrc,
           cbi.cont_ic, cbi.cont_lic)
       end
     end
-    
+
     l_eval && println(lio,lprefix,"contex returned ",result)
     return result
   end
@@ -268,7 +268,7 @@ end
        function seulex(rhs, t0::Real, T::Real,
                        x0::Vector, opt::AbstractOptionsODE)
            -> (t,x,retcode,stats)
-  
+
 
   `retcode` can have the following values:
 
@@ -278,12 +278,12 @@ end
 
 
   main call for using Fortran seulex solver.
-  
+
   This solver support problems with special structure, see
   `help_specialstructure`.
-  
+
   In `opt` the following options are used:
-  
+
       ╔═════════════════╤══════════════════════════════════════════╤═════════╗
       ║  Option OPT_…   │ Description                              │ Default ║
       ╠═════════════════╪══════════════════════════════════════════╪═════════╣
@@ -411,18 +411,18 @@ function seulex_i32(rhs, t0::Real, T::Real,
   return seulex_impl(rhs,t0,T,x0,opt,SeulexArguments{Int32}(Int32(0)))
 end
 
-function seulex_impl(rhs, 
-        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE, 
+function seulex_impl(rhs,
+        t0::Real, T::Real, x0::Vector, opt::AbstractOptionsODE,
         args::SeulexArguments{FInt}) where FInt<:FortranInt
-  
+
   (lio,l,l_g,l_solver,lprefix) = solver_start("seulex",rhs,t0,T,x0,opt)
-  
+
   (method_seulex, method_contex) = getAllMethodPtrs(
      (FInt == Int64) ? DL_SEULEX : DL_SEULEX_I32 )
 
   (d,nrdense,scalarFlag,rhs_mode,output_mode,output_fcn) =
     solver_extract_commonOpt(t0,T,x0,opt,args)
-  
+
   args.ITOL = [ scalarFlag ? 0 : 1 ]
   args.IOUT = [ FInt( output_mode == OUTPUTFCN_NEVER ? 0 :
                      (output_mode == OUTPUTFCN_DENSE ? 2 : 1) )]
@@ -443,30 +443,30 @@ function seulex_impl(rhs,
   catch e
     throw(ArgumentErrorODE("Option '$OPT': Not valid",:opt,e))
   end
-  
+
   # WORK memory
   ljac = flag_jband ? 1+args.MLJAC[1]+args.MUJAC[1] : NM1
   lmas = (!flag_implct) ? 0 :
          (args.MLMAS[1] == NM1) ? NM1 : 1+args.MLMAS[1]+args.MUMAS[1]
   le   = flag_jband ? 1+2*args.MLJAC[1]+args.MUJAC[1] : NM1
   KM2  = 2+KM*ceil(FInt,(KM+3)/2)
-  
+
   args.LWORK = [ (M1==0) ? d*(ljac+lmas+le+KM+8)+4*KM+20+KM2*nrdense :
                            d*(ljac+KM+8)+NM1*(lmas+le)+4*KM+20+KM2*nrdense ]
   args.WORK = zeros(Float64,args.LWORK[1])
-  
+
   # IWORK memory
   args.LIWORK = [ 2*d+KM+20+nrdense ]
   args.IWORK = zeros(FInt,args.LIWORK[1])
-  
+
   try
     OPT=OPT_RHSAUTONOMOUS;
     rhsautonomous = convert(Bool,getOption(opt,OPT,false))
     args.IFCN = [ rhsautonomous ? 0 : 1 ]
 
-    OPT=OPT_TRANSJTOH; 
+    OPT=OPT_TRANSJTOH;
     transjtoh  = convert(Bool,getOption(opt,OPT,false))
-    @assert (!transjtoh) || 
+    @assert (!transjtoh) ||
             ( (!flag_jband) && (!flag_implct ))  string(
             "Does not work, if the jacobian is banded or if the system ",
             " has a mass matrix (≠Id).")
@@ -474,24 +474,24 @@ function seulex_impl(rhs,
 
     OPT=OPT_MAXSTEPS; args.IWORK[2] = convert(FInt,getOption(opt,OPT,100000))
     @assert 0 < args.IWORK[2]
-    
+
     args.IWORK[3] = KM
 
     OPT = OPT_STEPSIZESEQUENCE
     args.IWORK[4] = convert(FInt,getOption(opt,OPT,2))
     @assert 1 ≤ args.IWORK[4] ≤ 4
-    
+
     OPT = OPT_LAMBDADENSE
     args.IWORK[5] = convert(FInt,getOption(opt,OPT,0))
     @assert args.IWORK[5] ∈ (0,1)
-    
+
     args.IWORK[6] = nrdense
 
     for k in 1:nrdense
       args.IWORK[20+k] = k
     end
 
-    args.IWORK[9] = M1 
+    args.IWORK[9] = M1
     args.IWORK[10] = M2
 
     OPT=OPT_EPS; args.WORK[1]=convert(Float64,getOption(opt,OPT,1e-16))
@@ -504,7 +504,7 @@ function seulex_impl(rhs,
     args.WORK[3] = convert(Float64,getOption(opt,OPT,min(1e-4,args.RTOL[1])))
     @assert !(args.WORK[3]==0)
 
-    OPT = OPT_SSSELECTPAR1; 
+    OPT = OPT_SSSELECTPAR1;
     args.WORK[4] = convert(Float64,getOption(opt,OPT,0.1))
     @assert 0 < args.WORK[4]
 
@@ -523,11 +523,11 @@ function seulex_impl(rhs,
     OPT = OPT_RHO2
     args.WORK[8] = convert(Float64,getOption(opt,OPT,0.8))
     @assert 0 < args.WORK[8]
-    
+
     OPT = OPT_RHO
     args.WORK[9] = convert(Float64,getOption(opt,OPT,0.93))
     @assert 0 < args.WORK[9]
-    
+
     OPT = OPT_WORKFORRHS
     args.WORK[10] = convert(Float64,getOption(opt,OPT,1.0))
     @assert 0 < args.WORK[10]
@@ -599,13 +599,13 @@ function seulex_impl(rhs,
      Ptr{Cvoid}, Ptr{FInt},                      # Soloutfunc, IOUT
      Ptr{Float64}, Ptr{FInt},                    # WORK, LWORK
      Ptr{FInt}, Ptr{FInt},                       # IWORK, LIWORK
-     Ptr{Float64}, Ref{SeulexInternalCallInfos}, # RPAR, IPAR 
+     Ptr{Float64}, Ref{SeulexInternalCallInfos}, # RPAR, IPAR
      Ptr{FInt},                                  # IDID
     ),
     args.N, args.FCN, args.IFCN,
     args.t, args.x, args.tEnd,
     args.H,
-    args.RTOL, args.ATOL, args.ITOL, 
+    args.RTOL, args.ATOL, args.ITOL,
     args.JAC, args.IJAC, args.MLJAC, args.MUJAC,
     args.MAS, args.IMAS, args.MLMAS, args.MUMAS,
     args.SOLOUT, args.IOUT,
@@ -637,8 +637,8 @@ function seulex_impl(rhs,
   return ( args.t[1], args.x, args.IDID[1], stats)
 end
 
-"""  
-  ## Compile SEULEX 
+"""
+  ## Compile SEULEX
 
   The julia ODEInterface tries to compile and link the solvers
   automatically at the build-time of this module. The following
@@ -646,101 +646,101 @@ end
   one wants to change/add some compiler options.
 
   The Fortran source code can be found at:
-  
-       http://www.unige.ch/~hairer/software.html 
-  
+
+       http://www.unige.ch/~hairer/software.html
+
   See `help_seulex_license` for the licsense information.
-  
+
   ### Using `gfortran` and 64bit integers (Linux and Mac)
-  
+
   Here is an example how to compile SEULEX with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapackc.o lapackc.f
-       gfortran -c -fPIC -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o seulex.o seulex.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
 
-       gfortran -shared -fPIC -o seulex.so 
+       gfortran -shared -fPIC -o seulex.so
                 seulex.o dc_lapack.o lapack.o lapackc.o
        gfortran -shared -fPIC -o seulex.dylib
                 seulex.o dc_lapack.o lapack.o lapackc.o
-  
+
   ### Using `gfortran` and 64bit integers (Windows)
-  
+
   Here is an example how to compile SEULEX with `Float64` reals and
   `Int64` integers with `gfortran`:
-  
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack.o dc_lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapack.o lapack.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o lapackc.o lapackc.f
-       gfortran -c -fdefault-integer-8 
-                -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-integer-8
+                -fdefault-real-8 -fdefault-double-8
                 -o seulex.o seulex.f
-  
+
   In order to get create a shared library (from the object file above) use
-  
-       gfortran -shared -o seulex.so 
+
+       gfortran -shared -o seulex.so
                 seulex.o dc_lapack.o lapack.o lapackc.o
-  
+
   ### Using `gfortran` and 32bit integers (Linux and Mac)
-  
+
   Here is an example how to compile SEULEX with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
-                -o lapackc_i32.o lapackc.f 
-       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
+                -o lapackc_i32.o lapackc.f
+       gfortran -c -fPIC -fdefault-real-8 -fdefault-double-8
                 -o seulex_i32.o seulex.f
-  
+
   In order to get create a shared library (from the object file above) use
   one of the forms below (1st for Linux, 2nd for Mac):
-  
-       gfortran -shared -fPIC -o seulex_i32.so 
+
+       gfortran -shared -fPIC -o seulex_i32.so
                  seulex_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
        gfortran -shared -fPIC -o seulex_i32.dylib
                  seulex_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
-  
+
   ### Using `gfortran` and 32bit integers (Windows)
-  
+
   Here is an example how to compile SEULEX with `Float64` reals and
   `Int32` integers with `gfortran`:
-  
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o dc_lapack_i32.o dc_lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o lapack_i32.o lapack.f
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
-                -o lapackc_i32.o lapackc.f 
-       gfortran -c -fdefault-real-8 -fdefault-double-8 
+       gfortran -c -fdefault-real-8 -fdefault-double-8
+                -o lapackc_i32.o lapackc.f
+       gfortran -c -fdefault-real-8 -fdefault-double-8
                 -o seulex_i32.o seulex.f
-  
+
   In order to get create a shared library (from the object file above) use:
 
        gfortran -shared -o seulex_i32.dll
                  seulex_i32.o dc_lapack_i32.o lapack_i32.o lapackc_i32.o
-  
+
   """
 function help_seulex_compile()
   return Docs.doc(help_seulex_compile)
@@ -756,8 +756,8 @@ end
 push!(solverInfo,
   SolverInfo("seulex",
     "Extrapolation method based on the linearly implicit Eueler method",
-    tuple(:OPT_RTOL, :OPT_ATOL, 
-          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN, 
+    tuple(:OPT_RTOL, :OPT_ATOL,
+          :OPT_OUTPUTMODE, :OPT_OUTPUTFCN,
           :OPT_M1, :OPT_M2,
           :OPT_RHSAUTONOMOUS,
           :OPT_MASSMATRIX,

--- a/src/SoloutEval.jl
+++ b/src/SoloutEval.jl
@@ -8,7 +8,7 @@ macro import_outputfcn()
           OUTPUTFCN_MODE,
           OUTPUTFCN_NEVER, OUTPUTFCN_WODENSE, OUTPUTFCN_DENSE,
           OUTPUTFCN_RETURN_VALUE,
-          OUTPUTFCN_RET_STOP, 
+          OUTPUTFCN_RET_STOP,
           OUTPUTFCN_RET_CONTINUE, OUTPUTFCN_RET_CONTINUE_XCHANGED
   )
 end
@@ -18,19 +18,19 @@ end
 
 @doc """
   Possible reasons for calling the `OPT_OUTPUTFCN`
-  """ 
+  """
 OUTPUTFCN_CALL_REASON
 
-@doc """`OPT_OUTPUTFCN` is called for 1st time.""" 
+@doc """`OPT_OUTPUTFCN` is called for 1st time."""
 OUTPUTFCN_CALL_INIT
 
 @doc """
-  `OPT_OUTPUTFCN` is called after a successfull 
+  `OPT_OUTPUTFCN` is called after a successfull
   integration step
-  """ 
+  """
 OUTPUTFCN_CALL_STEP
 
-@doc """`OPT_OUTPUTFCN` is called for the last time.""" 
+@doc """`OPT_OUTPUTFCN` is called for the last time."""
 OUTPUTFCN_CALL_DONE
 
 @enum(OUTPUTFCN_MODE,
@@ -38,22 +38,22 @@ OUTPUTFCN_CALL_DONE
 
 @doc """Possible mode for calling the `OPT_OUTPUTFCN`.
 
-see `OPT_OUTPUTFCN` and `OPT_OUTPUTMODE`""" 
+see `OPT_OUTPUTFCN` and `OPT_OUTPUTMODE`"""
 OUTPUTFCN_MODE
 
-@doc """`OPT_OUTPUTFCN` is never called."""  
+@doc """`OPT_OUTPUTFCN` is never called."""
 OUTPUTFCN_NEVER
 
 @doc """
-  `OPT_OUTPUTFCN` is called after every successfull step, 
+  `OPT_OUTPUTFCN` is called after every successfull step,
   but no support for dense output.
   """
 OUTPUTFCN_WODENSE
 
 @doc """
-  `OPT_OUTPUTFCN` is called after every successfull step 
+  `OPT_OUTPUTFCN` is called after every successfull step
   and dense output is supported.
-  """ 
+  """
 OUTPUTFCN_DENSE
 
 @enum(OUTPUTFCN_RETURN_VALUE,
@@ -85,7 +85,7 @@ function output_fcn_donothing(args...)
 end
 
 """
-  (Dummy-)eval_sol_function, throwing an error, telling the caller, 
+  (Dummy-)eval_sol_function, throwing an error, telling the caller,
   that this is the INIT-call of the output function.
   """
 function eval_sol_fcn_init(t)
@@ -97,7 +97,7 @@ function eval_sol_fcn_init(t)
 end
 
 """
-  (Dummy-)eval_sol_function, throwing an error, telling the caller, 
+  (Dummy-)eval_sol_function, throwing an error, telling the caller,
   that no evaluation is possible.
   """
 function eval_sol_fcn_noeval(t)
@@ -109,7 +109,7 @@ function eval_sol_fcn_noeval(t)
 end
 
 """
-  (Dummy-)eval_sol_function, throwing an error, telling the caller, 
+  (Dummy-)eval_sol_function, throwing an error, telling the caller,
   that this is the DONE-call of the output function.
   """
 function eval_sol_fcn_done(t)
@@ -122,16 +122,16 @@ end
 
 """
         function call_julia_output_fcn{CI<:ODEinternalCallInfos}(cbi::CI,
-          reason:: OUTPUTFCN_CALL_REASON, told::Float64,t::Float64, 
+          reason:: OUTPUTFCN_CALL_REASON, told::Float64,t::Float64,
           x::Vector{Float64},eval_sol_fcn::Function)
-  
+
   calls the julia output function with the given arguments.
-  
+
   This is more than a simple call, because this function takes care of
   logging, error-checking, etc.
   """
 function call_julia_output_fcn(cbi::CI,
-  reason:: OUTPUTFCN_CALL_REASON, told::Float64,t::Float64, 
+  reason:: OUTPUTFCN_CALL_REASON, told::Float64,t::Float64,
   x::Vector{Float64},eval_sol_fcn::Function) where CI<:ODEinternalCallInfos
 
   lprefix = "call_julia_output_fcn: "
@@ -145,7 +145,7 @@ function call_julia_output_fcn(cbi::CI,
             " extra_data=",cbi.output_data)
   end
   result = cbi.output_fcn(reason,told,t,x,eval_sol_fcn,cbi.output_data)
-  try 
+  try
     @assert isa(result,OUTPUTFCN_RETURN_VALUE)
   catch e
     throw(OutputErrorODE("Result was not an OUTPUTFCN_RETURN_VALUE",


### PR DESCRIPTION
From my experience, if you have ODEInterface not installed directly but only as a transitive dependency, then `Base.find_package("ODEInterface")` returns nothing and loading the Fortran libraries fails. This new way is more reliable.

I also deleted trailing whitespace from each Julia file (my editor does it automatically), but if that's not wanted just let me know and I'll drop that commit.

tip: you can ignore the whitespace changes by only looking at 7151615bae7a3b054448e0e25f0985b057f70c23 or by adding `?w=1` to the URL in the files tab (https://github.com/luchr/ODEInterface.jl/pull/25/files?w=1)