### PR TITLE
Support building for AppleSilicon

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -40,6 +40,7 @@ end
 
 windows_flag = Sys.iswindows()
 apple_flag = Sys.isapple()
+apple_silicon_flag = apple_flag && Sys.ARCH === :aarch64
 file_extension = nothing
 obj_files = []
 ignore_jll = read_env("ODEINTERFACE_IGNORE_JLL") != nothing
@@ -440,14 +441,14 @@ if build_script != nothing
   create_build_script()
 else
   # to build or not-to-build?
-  if VERSION >= v"1.3" && !ignore_jll
+  if VERSION >= v"1.3" && !ignore_jll && !apple_silicon_flag
     # Julia supports Artifacts and we don't build anything and we try
     # to use ODEInterface_jll
     exit()
   else
-    # either Julia version before v1.3 or we were asked to ignore
-    # ODEInterface_jll
-    # => in both cases we try to build:
+    # either Julia version is older than v1.3, we were asked to ignore
+    # ODEInterface_jll or we are on AppleSilicon
+    # => in all cases we try to build:
     adapt_to_os()
     build_with_gfortran()
   end

--- a/src/DLSolvers.jl
+++ b/src/DLSolvers.jl
@@ -159,7 +159,8 @@ function loadODESolvers(extrapaths::Vector=AbstractString[],
   if isempty(extrapaths)
     extrapaths = [ @__DIR__ ]
   end
-  use_jll = VERSION >= v"1.3" && !ignore_jll
+  apple_silicon = Sys.isapple() && Sys.ARCH === :aarch64
+  use_jll = VERSION >= v"1.3" && !ignore_jll && !apple_silicon
   if use_jll
     @eval ODEInterface begin
       using ODEInterface_jll

--- a/src/ODEInterface.jl
+++ b/src/ODEInterface.jl
@@ -597,6 +597,7 @@ function __init__()
   # at this stage dlSolversInfo should be empty, but
   # just to be sure
   empty!(dlSolversInfo)
+  loadODESolvers()
 end
 
 


### PR DESCRIPTION
This PR adds an `apple_silicon_flag` to the build function in `build.jl` to automatically opt into building locally when called on AppleSilicon hardware. Similarly, the `loadODESolvers()` function now looks for local binaries instead of using ODEInterface_jll.jl when run on AppleSilicon.

One other change I made was to add `loadODESolvers()` to the `__init__()` call so the function does not need to be manually invoked for every new session. However, I'm not sure if that is the right place for calling the function.

All tests in `runtests.jl` passed.